### PR TITLE
feat(express): streamable endpoint

### DIFF
--- a/examples/react-express/client/src/App.tsx
+++ b/examples/react-express/client/src/App.tsx
@@ -14,6 +14,9 @@ const App: React.FC = () => {
   const [loading, setLoading] = React.useState(false);
   const [validationError, setValidationError] = React.useState<O.Option<string>>(O.none);
   const [response, setResponse] = React.useState<O.Option<APIResult>>(O.none);
+  const [streaming, setStreaming] = React.useState(false);
+  const [streamChunks, setStreamChunks] = React.useState<string[]>([]);
+  const streamAbortRef = React.useRef<AbortController | null>(null);
 
   return (
     <div
@@ -77,7 +80,7 @@ const App: React.FC = () => {
       <div style={{ height: '100%' }}>
         <h3 style={{ textAlign: 'center' }}>Responses:</h3>
         <div>
-          {pipe(
+        {pipe(
             response,
             O.fold(
               () => <span>there is no data to show yet!</span>,
@@ -121,6 +124,87 @@ const App: React.FC = () => {
             (ID) => <TanstackQueryOutput id={ID} />
           )
         )}
+        <div style={{ marginTop: 30 }}>
+          <h3>Stream demo</h3>
+          <div style={{ marginBottom: 8 }}>
+            <button
+              disabled={streaming}
+              onClick={async () => {
+                setStreamChunks([]);
+                setStreaming(true);
+                const controller = new AbortController();
+                streamAbortRef.current = controller;
+
+                try {
+                  const result = await apiClient.streamUsers()();
+                  if (E.isLeft(result)) {
+                    // handle error by stopping stream
+                    setStreaming(false);
+                    streamAbortRef.current = null;
+                    return;
+                  }
+
+                  const stream = result.right as any;
+
+                  // Web ReadableStream
+                  if (stream && typeof stream.getReader === 'function') {
+                    const reader = stream.getReader();
+                    const decoder = new TextDecoder();
+
+                    // eslint-disable-next-line no-constant-condition
+                    while (true) {
+                      const { done, value } = await reader.read();
+                      if (done) break;
+                      if (value) {
+                        const chunk = decoder.decode(value, { stream: true });
+                        setStreamChunks((c) => [...c, chunk]);
+                      }
+                    }
+                  } else if (stream && typeof stream[Symbol.asyncIterator] === 'function') {
+                    // Async-iterable (Node stream with async iterator)
+                    const decoder = new TextDecoder();
+                    for await (const chunk of stream) {
+                      const s = typeof chunk === 'string' ? chunk : decoder.decode(chunk, { stream: true });
+                      setStreamChunks((c) => [...c, s]);
+                    }
+                  } else if (stream && typeof stream.on === 'function') {
+                    // Node-style stream events
+                    const decoder = new TextDecoder();
+                    await new Promise<void>((resolve) => {
+                      stream.on('data', (chunk: any) => {
+                        const s = typeof chunk === 'string' ? chunk : decoder.decode(chunk, { stream: true });
+                        setStreamChunks((c) => [...c, s]);
+                      });
+                      stream.on('end', () => resolve());
+                      stream.on('close', () => resolve());
+                    });
+                  }
+                } catch (e) {
+                  // abort or network error
+                } finally {
+                  setStreaming(false);
+                  streamAbortRef.current = null;
+                }
+              }}
+            >
+              {streaming ? 'streaming...' : 'Start stream demo'}
+            </button>
+
+            <button
+              style={{ marginLeft: 8 }}
+              disabled={!streaming}
+              onClick={() => {
+                streamAbortRef.current?.abort();
+              }}
+            >
+              Stop
+            </button>
+          </div>
+
+          <div style={{ whiteSpace: 'pre-wrap', border: '1px solid #ddd', padding: 8 }}>
+            {streamChunks.length === 0 ? <em>No stream data yet</em> : streamChunks.join('')}
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/examples/react-express/client/src/api.ts
+++ b/examples/react-express/client/src/api.ts
@@ -2,7 +2,7 @@ import { IOError, IOTSCodec } from '@ts-endpoint/core';
 import { GetFetchHTTPClient } from '@ts-endpoint/http-client';
 import * as E from 'fp-ts/lib/Either';
 import { pipe } from 'fp-ts/lib/function';
-import { getUser } from 'shared';
+import { getUser, streamUsers } from 'shared';
 
 export const apiClient = GetFetchHTTPClient(
   {
@@ -11,7 +11,7 @@ export const apiClient = GetFetchHTTPClient(
     protocol: 'http',
     port: 3000,
   },
-  { getUser },
+  { getUser, streamUsers },
   {
     decode: (schema: IOTSCodec<any, any>) => (input: unknown) => {
       return pipe(

--- a/examples/react-express/server/package.json
+++ b/examples/react-express/server/package.json
@@ -12,15 +12,15 @@
     "lint": "eslint src"
   },
   "devDependencies": {
-    "@types/express": "^5.0.3",
+    "@types/express": "^5.0.6",
     "typescript": "^5.8.2"
   },
   "dependencies": {
-    "express": "^5.1.0",
-    "fp-ts": "^2.8.2",
-    "shared": "workspace:*",
     "@ts-endpoint/core": "workspace:*",
     "@ts-endpoint/express": "workspace:*",
-    "@ts-endpoint/test": "workspace:*"
+    "@ts-endpoint/test": "workspace:*",
+    "express": "^5.2.1",
+    "fp-ts": "^2.8.2",
+    "shared": "workspace:*"
   }
 }

--- a/examples/react-express/server/src/index.ts
+++ b/examples/react-express/server/src/index.ts
@@ -8,6 +8,8 @@ import * as E from 'fp-ts/lib/Either.js';
 import { pipe } from 'fp-ts/lib/pipeable.js';
 import * as TA from 'fp-ts/lib/TaskEither.js';
 import { getUser } from 'shared';
+import { streamUsers } from 'shared';
+import { Readable } from 'stream';
 
 const database = [
   { id: 1, name: 'John', surname: 'Doe', age: 22 },
@@ -92,6 +94,16 @@ AddEndpointIOTS(getUser, ({ params: { id } }) => {
       statusCode: 200,
     }))
   );
+});
+
+AddEndpointIOTS(streamUsers, () => {
+  const stream = Readable.from(['chunk1\n', 'chunk2\n', 'chunk3\n']);
+
+  return TA.right({
+    stream,
+    statusCode: 200,
+    headers: { 'Content-Type': 'text/plain' },
+  });
 });
 
 AddEndpointEffect(TestEndpoints.Actor.Get, ({ params: { id } }) => {

--- a/examples/react-express/shared/src/index.ts
+++ b/examples/react-express/shared/src/index.ts
@@ -1,6 +1,7 @@
 import { Endpoint } from '@ts-endpoint/core';
 import * as t from 'io-ts';
 import { NumberFromString } from 'io-ts-types/lib/NumberFromString.js';
+import { StreamOutput } from '@ts-endpoint/core';
 
 const User = t.strict({
   name: t.string,
@@ -15,6 +16,12 @@ export const getUser = Endpoint({
   Input: {
     Params: t.type({ id: NumberFromString }),
   },
+});
+
+export const streamUsers = Endpoint({
+  Method: 'GET',
+  getPath: () => `users/stream`,
+  Output: StreamOutput(t.string),
 });
 
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@commitlint/cli": "^19.8.0",
     "@commitlint/config-conventional": "^19.8.0",
     "@eslint/js": "^9.24.0",
+    "@types/node": "^22",
     "@vitest/coverage-v8": "^4.0.18",
     "eslint": "^9.24.0",
     "eslint-config-prettier": "^10.1.2",

--- a/packages/core/src/Codec.ts
+++ b/packages/core/src/Codec.ts
@@ -49,6 +49,19 @@ export interface IOTSCodec<A, B> {
 
 export type Codec<A, B = A, R = never> = EffectCodec<A, B, R> | IOTSCodec<A, B>;
 
+// A special codec that marks an endpoint output as a streaming response.
+// Runtime-wise it behaves as a passthrough codec for unknown data, but
+// carries a marker property so the `Endpoint` constructor can detect
+// streaming outputs and set the `Stream` flag accordingly.
+export const StreamOutput: IOTSCodec<unknown, unknown> & { __isStreamOutput: true } = {
+  encode: (b: unknown) => b,
+  decode: (b: unknown) => ({ _tag: 'Right', right: b }) as Either<ValidationError[], unknown>,
+  name: 'StreamOutput',
+  __isStreamOutput: true,
+};
+
+export type StreamOutputCodec = typeof StreamOutput;
+
 export type InferCodec<C> =
   C extends IOTSRecordCodec<infer A, infer B>
     ? IOTSRecordCodec<A, B>

--- a/packages/core/src/Codec.ts
+++ b/packages/core/src/Codec.ts
@@ -32,7 +32,7 @@ export interface ValidationError {
 // Codec
 // -------------------------------------------------------------------------------------
 
-export type EffectCodec<A, B = A, R = never> = {
+export type EffectCodec<A, B = A, R = any> = {
   Type: A;
   Encoded: B;
   Context: R;
@@ -47,7 +47,7 @@ export interface IOTSCodec<A, B> {
   name: string;
 }
 
-export type Codec<A, B = A, R = never> = EffectCodec<A, B, R> | IOTSCodec<A, B>;
+export type Codec<A, B = A, R = any> = EffectCodec<A, B, R> | IOTSCodec<A, B>;
 
 // A special codec that marks an endpoint output as a streaming response.
 // Runtime-wise it behaves as a passthrough codec for unknown data, but

--- a/packages/core/src/Codec.ts
+++ b/packages/core/src/Codec.ts
@@ -53,14 +53,17 @@ export type Codec<A, B = A, R = never> = EffectCodec<A, B, R> | IOTSCodec<A, B>;
 // Runtime-wise it behaves as a passthrough codec for unknown data, but
 // carries a marker property so the `Endpoint` constructor can detect
 // streaming outputs and set the `Stream` flag accordingly.
-export const StreamOutput: IOTSCodec<unknown, unknown> & { __isStreamOutput: true } = {
-  encode: (b: unknown) => b,
-  decode: (b: unknown) => ({ _tag: 'Right', right: b }) as Either<ValidationError[], unknown>,
-  name: 'StreamOutput',
-  __isStreamOutput: true,
+export const StreamOutput = <A, B = A>(
+  codec: Codec<A, B>
+): Codec<A, B> & { __isStreamOutput: true } => {
+  return {
+    ...codec,
+    name: 'StreamOutput',
+    __isStreamOutput: true,
+  };
 };
 
-export type StreamOutputCodec = typeof StreamOutput;
+export type StreamOutputCodec<A, B = A> = Codec<A, B> & { __isStreamOutput: true };
 
 export type InferCodec<C> =
   C extends IOTSRecordCodec<infer A, infer B>

--- a/packages/core/src/Endpoint.ts
+++ b/packages/core/src/Endpoint.ts
@@ -47,6 +47,7 @@ export interface Endpoint<
         Body?: M extends 'POST' | 'PUT' | 'PATCH' | 'DELETE' ? B : never;
       };
   Output: O;
+  Stream?: boolean;
 }
 
 export type MinimalEndpoint = Omit<
@@ -132,6 +133,7 @@ export type EndpointInstance<E extends MinimalEndpoint> = {
       : (f: (paramName: keyof runtimeType<InferEndpointParams<E>['params']>) => string) => string;
   Method: E['Method'];
   Output: E['Output'];
+  Stream?: E['Stream'];
 } & (E['Input'] extends undefined
   ? {
       Input?: never;
@@ -200,6 +202,7 @@ export function Endpoint<
     },
     Output: e.Output,
     ...(e.Errors ? { Errors: e.Errors } : {}),
+    ...(e.Stream !== undefined ? { Stream: e.Stream } : {}),
     Input: {
       ...(e.Input?.Body ? { Body: e.Input.Body } : {}),
       ...(e.Input?.Headers ? { Headers: e.Input.Headers } : {}),

--- a/packages/core/src/Endpoint.ts
+++ b/packages/core/src/Endpoint.ts
@@ -167,9 +167,9 @@ export function Endpoint<
   B extends Codec<any, any> | undefined = undefined,
   P extends RecordCodec<any> | undefined = undefined,
   E extends EndpointErrors<never, Codec<any, any>> | undefined = undefined,
->(e: Endpoint<M, O, H, Q, B, P, E> & (S extends undefined ? {} : { Stream: S })): EndpointInstance<
-  Endpoint<M, O, H, Q, B, P, E>
-> & (S extends undefined ? {} : { Stream: S }) {
+>(
+  e: Endpoint<M, O, H, Q, B, P, E> & (S extends undefined ? {} : { Stream: S })
+): EndpointInstance<Endpoint<M, O, H, Q, B, P, E>> & (S extends undefined ? {} : { Stream: S }) {
   // TODO: check if the headers are valid?
   // const headersWithWhiteSpaces = pipe(
   //   e.Input?.Headers?.props ?? {},

--- a/packages/core/src/Endpoint.ts
+++ b/packages/core/src/Endpoint.ts
@@ -16,6 +16,7 @@ import {
   type serializedType,
   type UndefinedsToPartial,
 } from './Codec.js';
+import type { StreamOutputCodec } from './Codec.js';
 import { addSlash } from './helpers.js';
 
 export type HTTPMethod = 'OPTIONS' | 'HEAD' | 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
@@ -46,8 +47,7 @@ export interface Endpoint<
         Query?: Q;
         Body?: M extends 'POST' | 'PUT' | 'PATCH' | 'DELETE' ? B : never;
       };
-  Output: O;
-  Stream?: boolean;
+  Output: O extends StreamOutputCodec ? StreamOutputCodec : O;
 }
 
 export type MinimalEndpoint = Omit<
@@ -133,7 +133,6 @@ export type EndpointInstance<E extends MinimalEndpoint> = {
       : (f: (paramName: keyof runtimeType<InferEndpointParams<E>['params']>) => string) => string;
   Method: E['Method'];
   Output: E['Output'];
-  Stream?: E['Stream'];
 } & (E['Input'] extends undefined
   ? {
       Input?: never;
@@ -158,18 +157,16 @@ export type EndpointInstance<E extends MinimalEndpoint> = {
  * Constructor function for an endpoint
  * @returns an EndpointInstance
  */
+
 export function Endpoint<
   M extends HTTPMethod,
   O extends Codec<any, any>,
-  const S extends boolean | undefined = undefined,
   Q extends RecordCodec<any> | undefined = undefined,
   H extends RecordCodec<any> | undefined = undefined,
   B extends Codec<any, any> | undefined = undefined,
   P extends RecordCodec<any> | undefined = undefined,
   E extends EndpointErrors<never, Codec<any, any>> | undefined = undefined,
->(
-  e: Endpoint<M, O, H, Q, B, P, E> & (S extends undefined ? {} : { Stream: S })
-): EndpointInstance<Endpoint<M, O, H, Q, B, P, E>> & (S extends undefined ? {} : { Stream: S }) {
+>(e: Endpoint<M, O, H, Q, B, P, E>): EndpointInstance<Endpoint<M, O, H, Q, B, P, E>> {
   // TODO: check if the headers are valid?
   // const headersWithWhiteSpaces = pipe(
   //   e.Input?.Headers?.props ?? {},
@@ -205,7 +202,10 @@ export function Endpoint<
     },
     Output: e.Output,
     ...(e.Errors ? { Errors: e.Errors } : {}),
-    ...(e.Stream !== undefined ? { Stream: e.Stream } : {}),
+    // If the caller explicitly provided a `Stream` flag, respect it.
+    // Otherwise detect the `StreamOutput` codec marker and set `Stream: true`.
+    // Detect the StreamOutput codec at runtime and set Stream:true when present.
+    ...((e.Output as any)?.__isStreamOutput === true ? { Stream: true } : {}),
     Input: {
       ...(e.Input?.Body ? { Body: e.Input.Body } : {}),
       ...(e.Input?.Headers ? { Headers: e.Input.Headers } : {}),
@@ -213,7 +213,7 @@ export function Endpoint<
       ...(e.Input?.Query ? { Query: e.Input.Query } : {}),
     },
   } as unknown as EndpointInstance<Endpoint<M, O, H, Q, B, P, E>> &
-    (S extends undefined ? {} : { Stream: S });
+    (O extends StreamOutputCodec ? { Stream: true } : { Stream?: undefined });
 }
 
 export type MinimalEndpointInstance = MinimalEndpoint & {

--- a/packages/core/src/Endpoint.ts
+++ b/packages/core/src/Endpoint.ts
@@ -295,9 +295,10 @@ export type EndpointInstanceEncodedParams<E extends MinimalEndpointInstance> = {
 export type InferEndpointInstanceParams<EI> =
   EI extends EndpointInstance<infer E> ? InferEndpointParams<E> : never;
 
-export type EndpointOutputType<L> = InferEndpointInstanceParams<L>['output'] extends StreamOutputCodec<any, any>
-  ? NodeJS.ReadableStream
-  : runtimeType<InferEndpointInstanceParams<L>['output']>;
+export type EndpointOutputType<L> =
+  InferEndpointInstanceParams<L>['output'] extends StreamOutputCodec<any, any>
+    ? NodeJS.ReadableStream
+    : runtimeType<InferEndpointInstanceParams<L>['output']>;
 
 export type EndpointDataOutputType<L, K extends string = 'data'> = L extends MinimalEndpointInstance
   ? InferEndpointInstanceParams<L>['output'] extends Codec<any, any>

--- a/packages/core/src/Endpoint.ts
+++ b/packages/core/src/Endpoint.ts
@@ -161,12 +161,15 @@ export type EndpointInstance<E extends MinimalEndpoint> = {
 export function Endpoint<
   M extends HTTPMethod,
   O extends Codec<any, any>,
+  const S extends boolean | undefined = undefined,
   Q extends RecordCodec<any> | undefined = undefined,
   H extends RecordCodec<any> | undefined = undefined,
   B extends Codec<any, any> | undefined = undefined,
   P extends RecordCodec<any> | undefined = undefined,
   E extends EndpointErrors<never, Codec<any, any>> | undefined = undefined,
->(e: Endpoint<M, O, H, Q, B, P, E>): EndpointInstance<Endpoint<M, O, H, Q, B, P, E>> {
+>(e: Endpoint<M, O, H, Q, B, P, E> & (S extends undefined ? {} : { Stream: S })): EndpointInstance<
+  Endpoint<M, O, H, Q, B, P, E>
+> & (S extends undefined ? {} : { Stream: S }) {
   // TODO: check if the headers are valid?
   // const headersWithWhiteSpaces = pipe(
   //   e.Input?.Headers?.props ?? {},
@@ -209,11 +212,13 @@ export function Endpoint<
       ...(e.Input?.Params ? { Params: e.Input.Params } : {}),
       ...(e.Input?.Query ? { Query: e.Input.Query } : {}),
     },
-  } as unknown as EndpointInstance<Endpoint<M, O, H, Q, B, P, E>>;
+  } as unknown as EndpointInstance<Endpoint<M, O, H, Q, B, P, E>> &
+    (S extends undefined ? {} : { Stream: S });
 }
 
 export type MinimalEndpointInstance = MinimalEndpoint & {
   getStaticPath: (f: (i?: any) => string) => string;
+  Stream?: boolean;
 };
 
 /**

--- a/packages/core/src/Endpoint.ts
+++ b/packages/core/src/Endpoint.ts
@@ -47,7 +47,7 @@ export interface Endpoint<
         Query?: Q;
         Body?: M extends 'POST' | 'PUT' | 'PATCH' | 'DELETE' ? B : never;
       };
-  Output: O extends StreamOutputCodec ? StreamOutputCodec : O;
+  Output: O extends StreamOutputCodec<infer A, infer B> ? StreamOutputCodec<A, B> : O;
 }
 
 export type MinimalEndpoint = Omit<
@@ -212,13 +212,11 @@ export function Endpoint<
       ...(e.Input?.Params ? { Params: e.Input.Params } : {}),
       ...(e.Input?.Query ? { Query: e.Input.Query } : {}),
     },
-  } as unknown as EndpointInstance<Endpoint<M, O, H, Q, B, P, E>> &
-    (O extends StreamOutputCodec ? { Stream: true } : { Stream?: undefined });
+  } as unknown as EndpointInstance<Endpoint<M, O, H, Q, B, P, E>>;
 }
 
 export type MinimalEndpointInstance = MinimalEndpoint & {
   getStaticPath: (f: (i?: any) => string) => string;
-  Stream?: boolean;
 };
 
 /**
@@ -250,7 +248,9 @@ export type TypeOfEndpointInstanceInput<E extends MinimalEndpointInstance> = [
   ? void
   : {
       [K in keyof NonNullable<E['Input']>]: NonNullable<E['Input']>[K] extends Codec<any, any>
-        ? UndefinedsToPartial<serializedType<NonNullable<E['Input']>[K]>>
+        ? K extends 'Query'
+          ? UndefinedsToPartial<serializedType<NonNullable<E['Input']>[K]>>
+          : UndefinedsToPartial<runtimeType<NonNullable<E['Input']>[K]>>
         : never;
     };
 
@@ -259,12 +259,12 @@ export type TypeOfEndpointInstance<E extends MinimalEndpointInstance> = {
   getStaticPath: E['getStaticPath'];
   Method: E['Method'];
   Input: TypeOfEndpointInstanceInput<E>;
-  Output: serializedType<E['Output']>;
+  Output: runtimeType<E['Output']>;
   Errors: {
     [K in keyof NonNullable<E['Errors']>]: NonNullable<E['Errors']>[K] extends RecordCodec<any>
       ? RecordCodecSerialized<NonNullable<E['Errors']>[K]>
       : NonNullable<E['Errors']>[K] extends Codec<any, any>
-        ? serializedType<NonNullable<E['Errors']>[K]>
+        ? runtimeType<NonNullable<E['Errors']>[K]>
         : never;
   };
 };
@@ -295,7 +295,9 @@ export type EndpointInstanceEncodedParams<E extends MinimalEndpointInstance> = {
 export type InferEndpointInstanceParams<EI> =
   EI extends EndpointInstance<infer E> ? InferEndpointParams<E> : never;
 
-export type EndpointOutputType<L> = runtimeType<InferEndpointInstanceParams<L>['output']>;
+export type EndpointOutputType<L> = InferEndpointInstanceParams<L>['output'] extends StreamOutputCodec<any, any>
+  ? NodeJS.ReadableStream
+  : runtimeType<InferEndpointInstanceParams<L>['output']>;
 
 export type EndpointDataOutputType<L, K extends string = 'data'> = L extends MinimalEndpointInstance
   ? InferEndpointInstanceParams<L>['output'] extends Codec<any, any>
@@ -322,8 +324,8 @@ export type EndpointParamsType<G> = G extends MinimalEndpointInstance
   : never;
 
 export type EndpointQueryEncoded<L> = L extends MinimalEndpointInstance
-  ? runtimeType<InferEndpointInstanceParams<L>['query']>
-  : runtimeType<InferEndpointParams<L>['query']>;
+  ? serializedType<InferEndpointInstanceParams<L>['query']>
+  : serializedType<InferEndpointParams<L>['query']>;
 
 type DecodeUnknown<C, E> = (e: unknown, overrideOptions?: any) => Either<E, EncodedType<C>>;
 

--- a/packages/core/src/Endpoint.ts
+++ b/packages/core/src/Endpoint.ts
@@ -248,9 +248,7 @@ export type TypeOfEndpointInstanceInput<E extends MinimalEndpointInstance> = [
   ? void
   : {
       [K in keyof NonNullable<E['Input']>]: NonNullable<E['Input']>[K] extends Codec<any, any>
-        ? K extends 'Query'
-          ? UndefinedsToPartial<serializedType<NonNullable<E['Input']>[K]>>
-          : UndefinedsToPartial<runtimeType<NonNullable<E['Input']>[K]>>
+        ? UndefinedsToPartial<serializedType<NonNullable<E['Input']>[K]>>
         : never;
     };
 

--- a/packages/core/src/__test__/endpoint.spec.ts
+++ b/packages/core/src/__test__/endpoint.spec.ts
@@ -43,4 +43,45 @@ describe('Endpoint', () => {
       Output: Schema.Struct({ crayons: Schema.Array(Schema.String) }),
     });
   });
+
+  it('creates an endpoint with Stream property set to true', () => {
+    const streamEndpoint = Endpoint({
+      Input: {
+        Params: Schema.Struct({ id: Schema.Number }),
+      },
+      Method: 'GET',
+      getPath: ({ id }) => `users/${id.toString()}/stream`,
+      Output: Schema.Struct({ data: Schema.String }),
+      Stream: true,
+    });
+
+    expect(streamEndpoint.Stream).toBe(true);
+  });
+
+  it('creates an endpoint with Stream property set to false', () => {
+    const nonStreamEndpoint = Endpoint({
+      Input: {
+        Params: Schema.Struct({ id: Schema.Number }),
+      },
+      Method: 'GET',
+      getPath: ({ id }) => `users/${id.toString()}/data`,
+      Output: Schema.Struct({ data: Schema.String }),
+      Stream: false,
+    });
+
+    expect(nonStreamEndpoint.Stream).toBe(false);
+  });
+
+  it('creates an endpoint without Stream property (undefined)', () => {
+    const regularEndpoint = Endpoint({
+      Input: {
+        Params: Schema.Struct({ id: Schema.Number }),
+      },
+      Method: 'GET',
+      getPath: ({ id }) => `users/${id.toString()}/data`,
+      Output: Schema.Struct({ data: Schema.String }),
+    });
+
+    expect(regularEndpoint.Stream).toBeUndefined();
+  });
 });

--- a/packages/core/src/__test__/endpoint.spec.ts
+++ b/packages/core/src/__test__/endpoint.spec.ts
@@ -1,5 +1,6 @@
 import { Schema } from 'effect';
 import { describe, expect, it } from 'vitest';
+import { StreamOutput } from '../Codec.js';
 import { Endpoint } from '../Endpoint.js';
 
 describe('Endpoint', () => {
@@ -44,18 +45,17 @@ describe('Endpoint', () => {
     });
   });
 
-  it('creates an endpoint with Stream property set to true', () => {
+  it('creates an endpoint with Stream output', () => {
     const streamEndpoint = Endpoint({
       Input: {
         Params: Schema.Struct({ id: Schema.Number }),
       },
       Method: 'GET',
       getPath: ({ id }) => `users/${id.toString()}/stream`,
-      Output: Schema.Struct({ data: Schema.String }),
-      Stream: true,
+      Output: StreamOutput,
     });
 
-    expect(streamEndpoint.Stream).toBe(true);
+    expect(streamEndpoint.Output.__isStreamOutput).toBe(true);
   });
 
   it('creates an endpoint with Stream property set to false', () => {
@@ -66,22 +66,8 @@ describe('Endpoint', () => {
       Method: 'GET',
       getPath: ({ id }) => `users/${id.toString()}/data`,
       Output: Schema.Struct({ data: Schema.String }),
-      Stream: false,
     });
 
-    expect(nonStreamEndpoint.Stream).toBe(false);
-  });
-
-  it('creates an endpoint without Stream property (undefined)', () => {
-    const regularEndpoint = Endpoint({
-      Input: {
-        Params: Schema.Struct({ id: Schema.Number }),
-      },
-      Method: 'GET',
-      getPath: ({ id }) => `users/${id.toString()}/data`,
-      Output: Schema.Struct({ data: Schema.String }),
-    });
-
-    expect(regularEndpoint.Stream).toBeUndefined();
+    expect((nonStreamEndpoint.Output as any).__isStreamOutput).toBeUndefined();
   });
 });

--- a/packages/core/src/__test__/endpoint.spec.ts
+++ b/packages/core/src/__test__/endpoint.spec.ts
@@ -52,7 +52,7 @@ describe('Endpoint', () => {
       },
       Method: 'GET',
       getPath: ({ id }) => `users/${id.toString()}/stream`,
-      Output: StreamOutput,
+      Output: StreamOutput(Schema.String),
     });
 
     expect(streamEndpoint.Output.__isStreamOutput).toBe(true);

--- a/packages/core/src/__typetests__/endpoint.stream.test-d.ts
+++ b/packages/core/src/__typetests__/endpoint.stream.test-d.ts
@@ -1,0 +1,54 @@
+import { Schema } from 'effect';
+import { expectTypeOf, test } from 'vitest';
+import { Endpoint } from '../Endpoint.js';
+
+const streamEndpoint = Endpoint({
+  Input: {
+    Params: Schema.Struct({ id: Schema.Number }),
+  },
+  Method: 'GET',
+  getPath: ({ id }) => `users/${id.toString()}/stream`,
+  Output: Schema.Struct({ data: Schema.String }),
+  Stream: true,
+});
+
+const nonStreamEndpoint = Endpoint({
+  Input: {
+    Params: Schema.Struct({ id: Schema.Number }),
+  },
+  Method: 'GET',
+  getPath: ({ id }) => `users/${id.toString()}/data`,
+  Output: Schema.Struct({ data: Schema.String }),
+  Stream: false,
+});
+
+const regularEndpoint = Endpoint({
+  Input: {
+    Params: Schema.Struct({ id: Schema.Number }),
+  },
+  Method: 'GET',
+  getPath: ({ id }) => `users/${id.toString()}/data`,
+  Output: Schema.Struct({ data: Schema.String }),
+});
+
+test('Stream property types', () => {
+  // Stream endpoint should have Stream property
+  expectTypeOf(streamEndpoint.Stream).toEqualTypeOf<boolean | undefined>();
+
+  // Non-stream endpoint should have Stream property
+  expectTypeOf(nonStreamEndpoint.Stream).toEqualTypeOf<boolean | undefined>();
+
+  // Regular endpoint should have Stream as optional
+  expectTypeOf(regularEndpoint.Stream).toEqualTypeOf<boolean | undefined>();
+
+  // Runtime checks
+  if (streamEndpoint.Stream !== undefined) {
+    expectTypeOf(streamEndpoint.Stream).toEqualTypeOf<boolean>();
+  }
+});
+
+test('Stream endpoint preserves other properties', () => {
+  expectTypeOf(streamEndpoint.Method).toEqualTypeOf<'GET'>();
+  expectTypeOf(streamEndpoint.Input.Params.fields.id).toEqualTypeOf<typeof Schema.Number>();
+  expectTypeOf(streamEndpoint.Output.fields.data).toEqualTypeOf<typeof Schema.String>();
+});

--- a/packages/core/src/__typetests__/endpoint.stream.test-d.ts
+++ b/packages/core/src/__typetests__/endpoint.stream.test-d.ts
@@ -22,29 +22,12 @@ const nonStreamEndpoint = Endpoint({
   Stream: false,
 });
 
-const regularEndpoint = Endpoint({
-  Input: {
-    Params: Schema.Struct({ id: Schema.Number }),
-  },
-  Method: 'GET',
-  getPath: ({ id }) => `users/${id.toString()}/data`,
-  Output: Schema.Struct({ data: Schema.String }),
-});
-
 test('Stream property types', () => {
-  // Stream endpoint should have Stream property
-  expectTypeOf(streamEndpoint.Stream).toEqualTypeOf<boolean | undefined>();
+  // Stream endpoint should have Stream = true
+  expectTypeOf(streamEndpoint.Stream).toEqualTypeOf<true>();
 
-  // Non-stream endpoint should have Stream property
-  expectTypeOf(nonStreamEndpoint.Stream).toEqualTypeOf<boolean | undefined>();
-
-  // Regular endpoint should have Stream as optional
-  expectTypeOf(regularEndpoint.Stream).toEqualTypeOf<boolean | undefined>();
-
-  // Runtime checks
-  if (streamEndpoint.Stream !== undefined) {
-    expectTypeOf(streamEndpoint.Stream).toEqualTypeOf<boolean>();
-  }
+  // Non-stream endpoint should have Stream = false
+  expectTypeOf(nonStreamEndpoint.Stream).toEqualTypeOf<false>();
 });
 
 test('Stream endpoint preserves other properties', () => {

--- a/packages/core/src/__typetests__/endpoint.stream.test-d.ts
+++ b/packages/core/src/__typetests__/endpoint.stream.test-d.ts
@@ -9,7 +9,7 @@ const streamEndpoint = Endpoint({
   },
   Method: 'GET',
   getPath: ({ id }) => `users/${id.toString()}/stream`,
-  Output: StreamOutput,
+  Output: StreamOutput(Schema.Struct({ id: Schema.Number })),
 });
 
 const nonStreamEndpoint = Endpoint({
@@ -23,7 +23,16 @@ const nonStreamEndpoint = Endpoint({
 
 test('Stream property types', () => {
   // Stream endpoint should have Stream = true
-  expectTypeOf(streamEndpoint.Output).toEqualTypeOf<StreamOutputCodec>();
+  expectTypeOf(streamEndpoint.Output).toEqualTypeOf<
+    StreamOutputCodec<
+      {
+        readonly id: number;
+      },
+      {
+        readonly id: number;
+      }
+    >
+  >();
 
   // Non-stream endpoint should not have a Stream property
   expectTypeOf(nonStreamEndpoint.Output).toEqualTypeOf<

--- a/packages/core/src/__typetests__/endpoint.stream.test-d.ts
+++ b/packages/core/src/__typetests__/endpoint.stream.test-d.ts
@@ -1,5 +1,6 @@
 import { Schema } from 'effect';
 import { expectTypeOf, test } from 'vitest';
+import { StreamOutput, type StreamOutputCodec } from '../Codec.js';
 import { Endpoint } from '../Endpoint.js';
 
 const streamEndpoint = Endpoint({
@@ -8,8 +9,7 @@ const streamEndpoint = Endpoint({
   },
   Method: 'GET',
   getPath: ({ id }) => `users/${id.toString()}/stream`,
-  Output: Schema.Struct({ data: Schema.String }),
-  Stream: true,
+  Output: StreamOutput,
 });
 
 const nonStreamEndpoint = Endpoint({
@@ -19,19 +19,22 @@ const nonStreamEndpoint = Endpoint({
   Method: 'GET',
   getPath: ({ id }) => `users/${id.toString()}/data`,
   Output: Schema.Struct({ data: Schema.String }),
-  Stream: false,
 });
 
 test('Stream property types', () => {
   // Stream endpoint should have Stream = true
-  expectTypeOf(streamEndpoint.Stream).toEqualTypeOf<true>();
+  expectTypeOf(streamEndpoint.Output).toEqualTypeOf<StreamOutputCodec>();
 
-  // Non-stream endpoint should have Stream = false
-  expectTypeOf(nonStreamEndpoint.Stream).toEqualTypeOf<false>();
+  // Non-stream endpoint should not have a Stream property
+  expectTypeOf(nonStreamEndpoint.Output).toEqualTypeOf<
+    Schema.Struct<{
+      data: typeof Schema.String;
+    }>
+  >();
 });
 
 test('Stream endpoint preserves other properties', () => {
   expectTypeOf(streamEndpoint.Method).toEqualTypeOf<'GET'>();
   expectTypeOf(streamEndpoint.Input.Params.fields.id).toEqualTypeOf<typeof Schema.Number>();
-  expectTypeOf(streamEndpoint.Output.fields.data).toEqualTypeOf<typeof Schema.String>();
+  // Output is a StreamOutput marker for stream endpoints, so we don't assert fields here.
 });

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@ts-endpoint/test": "workspace:*",
-    "@types/express": "^5.0.3",
+    "@types/express": "^5.0.6",
     "effect": "^3.14.8",
     "express": "^5.1.0",
     "fp-ts": "^2.16.9",

--- a/packages/express/src/Controller.ts
+++ b/packages/express/src/Controller.ts
@@ -1,8 +1,8 @@
 import { type TaskEither } from 'fp-ts/lib/TaskEither.js';
 import { type HTTPResponse, type HTTPStreamResponse } from './HTTPResponse.js';
 
-export type Controller<E, P, H, Q, B, R> = (
+export type Controller<E, P, H, Q, B, R, IsStream extends boolean | undefined = undefined> = (
   args: { params: P; headers: H; query: Q; body: B },
   req: Express.Request,
   res: Express.Response
-) => TaskEither<E, HTTPResponse<R> | HTTPStreamResponse>;
+) => TaskEither<E, IsStream extends true ? HTTPStreamResponse : HTTPResponse<R>>;

--- a/packages/express/src/Controller.ts
+++ b/packages/express/src/Controller.ts
@@ -1,8 +1,8 @@
 import { type TaskEither } from 'fp-ts/lib/TaskEither.js';
-import { type HTTPResponse } from './HTTPResponse.js';
+import { type HTTPResponse, type HTTPStreamResponse } from './HTTPResponse.js';
 
 export type Controller<E, P, H, Q, B, R> = (
   args: { params: P; headers: H; query: Q; body: B },
   req: Express.Request,
   res: Express.Response
-) => TaskEither<E, HTTPResponse<R>>;
+) => TaskEither<E, HTTPResponse<R> | HTTPStreamResponse>;

--- a/packages/express/src/Controller.ts
+++ b/packages/express/src/Controller.ts
@@ -1,3 +1,4 @@
+import type * as Express from 'express-serve-static-core';
 import { type TaskEither } from 'fp-ts/lib/TaskEither.js';
 import { type HTTPResponse, type HTTPStreamResponse } from './HTTPResponse.js';
 

--- a/packages/express/src/HTTPResponse.ts
+++ b/packages/express/src/HTTPResponse.ts
@@ -4,6 +4,12 @@ export interface HTTPResponse<T> {
   headers?: Record<string, string>;
 }
 
+export interface HTTPStreamResponse {
+  stream: NodeJS.ReadableStream;
+  statusCode: number;
+  headers?: Record<string, string>;
+}
+
 export interface ResponseError {
   statusCode: number;
   message?: string;

--- a/packages/express/src/__typetests__/addEndpoint.stream.test-d.ts
+++ b/packages/express/src/__typetests__/addEndpoint.stream.test-d.ts
@@ -1,0 +1,111 @@
+import { Readable } from 'stream';
+import { type Codec, Endpoint, type IOError } from '@ts-endpoint/core';
+import { Schema } from 'effect';
+import * as express from 'express';
+import * as E from 'fp-ts/lib/Either.js';
+import { pipe } from 'fp-ts/lib/function.js';
+import { assertType, describe, expectTypeOf, test } from 'vitest';
+import { type HTTPStreamResponse } from '../HTTPResponse.js';
+import { buildIOError, GetEndpointSubscriber } from '../index.js';
+
+const streamEndpoint = Endpoint({
+  Input: {
+    Params: Schema.Struct({ id: Schema.UUID }),
+  },
+  Method: 'GET',
+  getPath: ({ id }) => `users/${id}/stream`,
+  Output: Schema.Struct({ data: Schema.String }),
+});
+
+const regularEndpoint = Endpoint({
+  Input: {
+    Params: Schema.Struct({ id: Schema.UUID }),
+  },
+  Method: 'GET',
+  getPath: ({ id }) => `users/${id}/data`,
+  Output: Schema.Struct({ data: Schema.String }),
+});
+
+const router = express.Router();
+
+const decode =
+  <A, I, E = any>(s: Codec<A, I, E>, _parseOptions?: any) =>
+  (input: unknown, _transformOptions?: any): E.Either<IOError, any> => {
+    return pipe(
+      input,
+      Schema.decodeUnknownEither(s as any),
+      E.mapLeft((e) => buildIOError([e]))
+    );
+  };
+
+const registerRouter = GetEndpointSubscriber({ buildDecodeError: buildIOError, decode });
+const AddEndpoint = registerRouter(router);
+
+describe('Stream endpoint types', () => {
+  test('Should accept HTTPStreamResponse for streaming endpoint', () => {
+    const streamData = Readable.from(['chunk1', 'chunk2', 'chunk3']);
+
+    assertType<void>(
+      AddEndpoint(streamEndpoint, ({ params: { id } }) => () => {
+        assertType<string>(id);
+
+        const response: HTTPStreamResponse = {
+          stream: streamData,
+          statusCode: 200,
+          headers: { 'Content-Type': 'application/octet-stream' },
+        };
+
+        return Promise.resolve(E.right(response));
+      })
+    );
+  });
+
+  test('Should accept regular HTTPResponse for streaming endpoint', () => {
+    assertType<void>(
+      AddEndpoint(streamEndpoint, ({ params: { id } }) => () => {
+        assertType<string>(id);
+        return Promise.resolve(E.right({ body: { data: 'test' }, statusCode: 200 }));
+      })
+    );
+  });
+
+  test('Should accept HTTPStreamResponse for regular endpoint', () => {
+    const streamData = Readable.from(['chunk1', 'chunk2']);
+
+    assertType<void>(
+      AddEndpoint(regularEndpoint, ({ params: { id } }) => () => {
+        assertType<string>(id);
+
+        const response: HTTPStreamResponse = {
+          stream: streamData,
+          statusCode: 200,
+        };
+
+        return Promise.resolve(E.right(response));
+      })
+    );
+  });
+
+  test('Should accept regular HTTPResponse for regular endpoint', () => {
+    assertType<void>(
+      AddEndpoint(regularEndpoint, ({ params: { id } }) => () => {
+        assertType<string>(id);
+        return Promise.resolve(E.right({ body: { data: 'test' }, statusCode: 200 }));
+      })
+    );
+  });
+
+  test('HTTPStreamResponse type should have correct shape', () => {
+    const streamData = Readable.from(['test']);
+
+    const response: HTTPStreamResponse = {
+      stream: streamData,
+      statusCode: 200,
+      headers: { 'Content-Type': 'text/plain' },
+    };
+
+    expectTypeOf(response.stream).toEqualTypeOf<NodeJS.ReadableStream>();
+    expectTypeOf(response.statusCode).toEqualTypeOf<number>();
+    expectTypeOf(response.headers).toEqualTypeOf<Record<string, string> | undefined>();
+  });
+});

--- a/packages/express/src/__typetests__/addEndpoint.stream.test-d.ts
+++ b/packages/express/src/__typetests__/addEndpoint.stream.test-d.ts
@@ -1,5 +1,6 @@
 import { Readable } from 'stream';
 import { type Codec, Endpoint, type IOError } from '@ts-endpoint/core';
+import { StreamOutput } from '@ts-endpoint/core';
 import { Schema } from 'effect';
 import * as express from 'express';
 import * as E from 'fp-ts/lib/Either.js';
@@ -7,8 +8,6 @@ import { pipe } from 'fp-ts/lib/function.js';
 import { assertType, describe, expectTypeOf, test } from 'vitest';
 import { type HTTPStreamResponse } from '../HTTPResponse.js';
 import { buildIOError, GetEndpointSubscriber } from '../index.js';
-
-import { StreamOutput } from '@ts-endpoint/core';
 
 const streamEndpoint = Endpoint({
   Input: {

--- a/packages/express/src/__typetests__/addEndpoint.stream.test-d.ts
+++ b/packages/express/src/__typetests__/addEndpoint.stream.test-d.ts
@@ -8,14 +8,15 @@ import { assertType, describe, expectTypeOf, test } from 'vitest';
 import { type HTTPStreamResponse } from '../HTTPResponse.js';
 import { buildIOError, GetEndpointSubscriber } from '../index.js';
 
+import { StreamOutput } from '@ts-endpoint/core';
+
 const streamEndpoint = Endpoint({
   Input: {
     Params: Schema.Struct({ id: Schema.UUID }),
   },
   Method: 'GET',
   getPath: ({ id }) => `users/${id}/stream`,
-  Output: Schema.Struct({ data: Schema.String }),
-  Stream: true,
+  Output: StreamOutput(Schema.Struct({ data: Schema.String })),
 });
 
 const regularEndpoint = Endpoint({
@@ -43,9 +44,7 @@ const registerRouter = GetEndpointSubscriber({ buildDecodeError: buildIOError, d
 const AddEndpoint = registerRouter(router);
 
 describe('Stream endpoint types', () => {
-  test('Verify streamEndpoint has Stream: true', () => {
-    expectTypeOf(streamEndpoint.Stream).toEqualTypeOf<true>();
-  });
+  // stream marker is validated indirectly by controller typing tests below
 
   test('Should accept HTTPStreamResponse for streaming endpoint', () => {
     const streamData = Readable.from(['chunk1', 'chunk2', 'chunk3']);

--- a/packages/express/src/index.ts
+++ b/packages/express/src/index.ts
@@ -127,7 +127,13 @@ export const GetEndpointSubscriber =
               res.set(httpResponse.headers);
             }
 
-            res.status(httpResponse.statusCode).send(httpResponse.body);
+            // Check if this is a streaming response
+            if ('stream' in httpResponse) {
+              res.status(httpResponse.statusCode);
+              httpResponse.stream.pipe(res);
+            } else {
+              res.status(httpResponse.statusCode).send(httpResponse.body);
+            }
           }
         )
       );

--- a/packages/express/src/index.ts
+++ b/packages/express/src/index.ts
@@ -10,6 +10,7 @@ import {
   type runtimeType,
   type UndefinedOrRuntime,
 } from '@ts-endpoint/core';
+import { type StreamOutputCodec } from '@ts-endpoint/core';
 import { type ParseError } from 'effect/ParseResult';
 import type * as express from 'express';
 import { sequenceS } from 'fp-ts/lib/Apply.js';
@@ -50,27 +51,27 @@ declare module './HKT.js' {
   }
 }
 
-type EndpointController<E extends MinimalEndpointInstance, M extends URIS = 'IOError'> = E extends {
-  Stream: true;
-}
-  ? Controller<
-      Kind<M, NonNullable<E['Errors']>>,
-      UndefinedOrRuntime<InferEndpointInstanceParams<E>['params']>,
-      UndefinedOrRuntime<InferEndpointInstanceParams<E>['headers']>,
-      UndefinedOrRuntime<InferEndpointInstanceParams<E>['query']>,
-      UndefinedOrRuntime<InferEndpointInstanceParams<E>['body']>,
-      runtimeType<InferEndpointInstanceParams<E>['output']>,
-      true
-    >
-  : Controller<
-      Kind<M, NonNullable<E['Errors']>>,
-      UndefinedOrRuntime<InferEndpointInstanceParams<E>['params']>,
-      UndefinedOrRuntime<InferEndpointInstanceParams<E>['headers']>,
-      UndefinedOrRuntime<InferEndpointInstanceParams<E>['query']>,
-      UndefinedOrRuntime<InferEndpointInstanceParams<E>['body']>,
-      runtimeType<InferEndpointInstanceParams<E>['output']>,
-      false | undefined
-    >;
+type EndpointController<E extends MinimalEndpointInstance, M extends URIS = 'IOError'> =
+  // If the endpoint output is a StreamOutputCodec, the controller must return an HTTPStreamResponse
+  E['Output'] extends StreamOutputCodec<any, any>
+    ? Controller<
+        Kind<M, NonNullable<E['Errors']>>,
+        UndefinedOrRuntime<InferEndpointInstanceParams<E>['params']>,
+        UndefinedOrRuntime<InferEndpointInstanceParams<E>['headers']>,
+        UndefinedOrRuntime<InferEndpointInstanceParams<E>['query']>,
+        UndefinedOrRuntime<InferEndpointInstanceParams<E>['body']>,
+        runtimeType<InferEndpointInstanceParams<E>['output']>,
+        true
+      >
+    : Controller<
+        Kind<M, NonNullable<E['Errors']>>,
+        UndefinedOrRuntime<InferEndpointInstanceParams<E>['params']>,
+        UndefinedOrRuntime<InferEndpointInstanceParams<E>['headers']>,
+        UndefinedOrRuntime<InferEndpointInstanceParams<E>['query']>,
+        UndefinedOrRuntime<InferEndpointInstanceParams<E>['body']>,
+        runtimeType<InferEndpointInstanceParams<E>['output']>,
+        false | undefined
+      >;
 
 export type AddEndpoint<M extends URIS = 'IOError'> = (
   router: express.Router,
@@ -96,6 +97,13 @@ interface GetEndpointSubscriberOptions<M extends URIS = 'IOError'> {
   decode: EndpointDecodeFn<Kind<M, unknown>>;
   buildDecodeError: (e: unknown) => Kind<M, unknown>;
 }
+
+const DEFAULT_STREAM_HEADERS_MAP = new Map([
+  ['Content-Type', 'text/event-stream'],
+  ['Cache-Control', 'no-cache'],
+  ['Connection', 'keep-alive'],
+  ['X-Accel-Buffering', 'no'], // Disable nginx buffering
+]);
 
 /**
  * Adds an endpoint to your router.
@@ -131,12 +139,14 @@ export const GetEndpointSubscriber =
         args,
         E.mapLeft((error) => buildDecodeError(error) as Kind<M, NonNullable<E['Errors']>>),
         TA.fromEither,
-        TA.chain((args) => controller(args as any, req, res)),
+        // controller return type can be a conditional (stream vs regular). Cast to any
+        // here to avoid complicated type union propagation through fp-ts helpers.
+        TA.chain((args) => controller(args as any, req, res) as any),
         TA.bimap(
           (e) => {
             return next(e);
           },
-          (httpResponse) => {
+          (httpResponse: any) => {
             if (httpResponse.headers !== undefined) {
               res.set(httpResponse.headers);
             }
@@ -145,6 +155,7 @@ export const GetEndpointSubscriber =
             if ('stream' in httpResponse) {
               const streamResponse = httpResponse as HTTPStreamResponse;
               res.status(streamResponse.statusCode);
+              res.setHeaders(DEFAULT_STREAM_HEADERS_MAP);
               streamResponse.stream.pipe(res);
             } else {
               const regularResponse = httpResponse as HTTPResponse<any>;

--- a/packages/http-client/src/GetHTTPClient.ts
+++ b/packages/http-client/src/GetHTTPClient.ts
@@ -5,6 +5,7 @@ import {
   type MinimalEndpointInstance,
   type runtimeType,
   type TypeOfEndpointInstance,
+  type StreamOutputCodec,
 } from '@ts-endpoint/core';
 import { type Either } from 'fp-ts/lib/Either.js';
 import { type ReaderTaskEither } from 'fp-ts/lib/ReaderTaskEither.js';
@@ -38,7 +39,7 @@ type FetchClientError<E, M extends URIS> =
 export type FetchClient<E extends MinimalEndpointInstance, M extends URIS> = ReaderTaskEither<
   'Input' extends RequiredKeys<E> ? TypeOfEndpointInstance<E>['Input'] : void,
   E['Errors'] extends undefined ? IOError : FetchClientError<E['Errors'], M>,
-  runtimeType<E['Output']>
+  E['Output'] extends StreamOutputCodec<any, any> ? NodeJS.ReadableStream : runtimeType<E['Output']>
 >;
 
 export type HTTPClient<A extends Record<string, MinimalEndpointInstance>, M extends URIS> = {

--- a/packages/react-admin/src/types.ts
+++ b/packages/react-admin/src/types.ts
@@ -75,7 +75,7 @@ type CustomEndpointParams<C> = (InferEndpointInstanceParams<C>['headers'] extend
 export type CustomEndpointFn<C extends MinimalEndpointInstance> = (
   params: CustomEndpointParams<C>,
   q?: any
-) => TE.TaskEither<IOError, runtimeType<InferEndpointInstanceParams<C>['output']>>;
+) => TE.TaskEither<IOError, EndpointOutputType<C>>;
 
 export type CustomEndpointsRecord<CC> =
   CC extends Record<string, MinimalEndpointInstance>

--- a/packages/tanstack-query/src/GetQueries.ts
+++ b/packages/tanstack-query/src/GetQueries.ts
@@ -3,13 +3,13 @@ import {
   type EndpointInstance,
   type EndpointOutputType,
   type EndpointParamsType,
-  type EndpointQueryEncoded,
   type EndpointsMapType,
   type InferEndpointParams,
   type IOError,
   type MinimalEndpoint,
   type MinimalEndpointInstance,
   type PartialSerializedType,
+  type serializedType,
   type TypeOfEndpointInstanceInput,
 } from '@ts-endpoint/core';
 import { throwTE } from '@ts-endpoint/core/lib/utils.js';
@@ -75,6 +75,7 @@ const toGetResourceQuery = <G extends MinimalEndpointInstance>(
 ): ResourceQuery<
   EndpointParamsType<G>,
   PartialSerializedType<InferEndpointParams<G>['query']>,
+  PartialSerializedType<InferEndpointParams<G>['query']>,
   EndpointOutputType<G>
 > => {
   const getKey = override?.getKey ?? getDefaultKey(key);
@@ -88,7 +89,12 @@ const toGetResourceQuery = <G extends MinimalEndpointInstance>(
   return {
     getKey,
     fetch,
-    useQuery: (p, q, d, prefix) => {
+    useQuery: (
+      p: EndpointParamsType<G>,
+      q?: PartialSerializedType<InferEndpointParams<G>['query']>,
+      d?: boolean,
+      prefix?: string
+    ) => {
       const qKey = getKey(p, q, d, prefix);
       return useQuery({
         queryKey: qKey,
@@ -101,33 +107,41 @@ const toGetResourceQuery = <G extends MinimalEndpointInstance>(
 export const toGetListResourceQuery = <L extends MinimalEndpointInstance>(
   getListFn: EndpointRequest<L>,
   key: string,
-  override?: GetQueryOverride<EndpointParamsType<L>, Partial<EndpointQueryEncoded<L>>>
+  override?: GetQueryOverride<EndpointParamsType<L>, any>
 ): ResourceQuery<
   EndpointParamsType<L>,
-  Partial<EndpointQueryEncoded<L>>,
+  any,
+  Partial<serializedType<InferEndpointParams<L>['query']>>,
   EndpointOutputType<L>
 > => {
   const getKey: GetKeyFn<
     EndpointParamsType<L>,
-    Partial<EndpointQueryEncoded<L>>
+    Partial<serializedType<InferEndpointParams<L>['query']>>
   > = override?.getKey ?? getDefaultKey(key);
 
   const fetch: QueryPromiseFunction<
     EndpointParamsType<L>,
-    Partial<EndpointQueryEncoded<L>>,
+    Partial<serializedType<InferEndpointParams<L>['query']>>,
     EndpointOutputType<L>
-  > = fetchQuery<EndpointParamsType<L>, Partial<EndpointQueryEncoded<L>>, EndpointOutputType<L>>(
-    (p, q) => {
-      return getListFn({
-        Params: p,
-        Query: q,
-      } as TypeOfEndpointInstanceInput<L>);
-    }
-  );
+  > = fetchQuery<
+    EndpointParamsType<L>,
+    Partial<serializedType<InferEndpointParams<L>['query']>>,
+    EndpointOutputType<L>
+  >((p, q) => {
+    return getListFn({
+      Params: p,
+      Query: q,
+    } as TypeOfEndpointInstanceInput<L>);
+  });
   return {
     getKey,
     fetch,
-    useQuery: (p, q, d, prefix) => {
+    useQuery: (
+      p: EndpointParamsType<L>,
+      q?: Partial<serializedType<InferEndpointParams<L>['query']>>,
+      d?: boolean,
+      prefix?: string
+    ) => {
       const qKey = getKey(p, q, d, prefix);
 
       return useQuery({

--- a/packages/tanstack-query/src/QueryProvider.ts
+++ b/packages/tanstack-query/src/QueryProvider.ts
@@ -23,7 +23,7 @@ type PatchedQueryProvider<
     ? {
         Custom: {
           [KK in keyof CC]: CC[KK] extends CustomQueryOverride<ES, infer P, infer Q, infer O>
-                  ? ResourceQuery<P, unknown, Q, O>
+            ? ResourceQuery<P, unknown, Q, O>
             : GetQueryProviderImplAt<ES, K, KK>;
         };
       }

--- a/packages/tanstack-query/src/QueryProvider.ts
+++ b/packages/tanstack-query/src/QueryProvider.ts
@@ -23,7 +23,7 @@ type PatchedQueryProvider<
     ? {
         Custom: {
           [KK in keyof CC]: CC[KK] extends CustomQueryOverride<ES, infer P, infer Q, infer O>
-            ? ResourceQuery<P, Q, O>
+                  ? ResourceQuery<P, unknown, Q, O>
             : GetQueryProviderImplAt<ES, K, KK>;
         };
       }

--- a/packages/tanstack-query/src/QueryProviderOverrides.ts
+++ b/packages/tanstack-query/src/QueryProviderOverrides.ts
@@ -1,12 +1,12 @@
 import { useQuery } from '@tanstack/react-query';
 import {
   type EndpointParamsType,
-  type EndpointQueryEncoded,
   type EndpointsMapType,
   type IOError,
   type InferEndpointInstanceParams,
   type MinimalEndpointInstance,
   type PartialSerializedType,
+  type EndpointQueryEncoded,
 } from '@ts-endpoint/core';
 import { type API } from '@ts-endpoint/resource-client';
 import * as Rec from 'fp-ts/lib/Record.js';
@@ -76,7 +76,7 @@ export const toOverrideQueries = <
             useQuery({
               queryKey: getKey(p),
               queryFn: ({ queryKey }) => {
-                return fetch(queryKey[1], queryKey[2], !!queryKey[3]);
+                  return fetch(queryKey[1], queryKey[2] as any, !!queryKey[3]);
               },
             }),
         };

--- a/packages/tanstack-query/src/QueryProviderOverrides.ts
+++ b/packages/tanstack-query/src/QueryProviderOverrides.ts
@@ -76,7 +76,7 @@ export const toOverrideQueries = <
             useQuery({
               queryKey: getKey(p),
               queryFn: ({ queryKey }) => {
-                  return fetch(queryKey[1], queryKey[2] as any, !!queryKey[3]);
+                return fetch(queryKey[1], queryKey[2] as any, !!queryKey[3]);
               },
             }),
         };

--- a/packages/tanstack-query/src/__test__/QueryProvider.effect.spec.ts
+++ b/packages/tanstack-query/src/__test__/QueryProvider.effect.spec.ts
@@ -89,8 +89,8 @@ describe('QueryProvider', () => {
 
     expect(Q.Actor.list).toBeDefined();
     const query = {
-      _end: 1,
-      _start: 0,
+      _end: '1',
+      _start: '0',
       ids: ['1'],
     };
     const actorKey = Q.Actor.list.getKey(undefined, query);
@@ -105,8 +105,8 @@ describe('QueryProvider', () => {
       },
       params: {
         ids: ['1'],
-        _end: 1,
-        _start: 0,
+        _end: '1',
+        _start: '0',
       },
       data: undefined,
       responseType: 'json',
@@ -116,6 +116,19 @@ describe('QueryProvider', () => {
       data: actorList.map(toExpectedActor),
       total: 2,
     });
+  });
+
+  it('accepts serialized query params for list', async () => {
+    const actorList: any[] = [];
+    axiosMock.request.mockResolvedValue({ data: { data: actorList, total: 0 } });
+
+    // passing encoded (string) values instead of runtime numbers should be allowed
+    const q = { _end: '1', _start: '0', ids: ['1'] };
+
+    const res = await Q.Actor.list.fetch(undefined, q as any);
+
+    expect(axiosMock.request).toHaveBeenCalled();
+    expect(res).toMatchObject({ data: actorList, total: 0 });
   });
 
   it('should have Actor Custom Query', async () => {

--- a/packages/tanstack-query/src/__test__/fixtures.ts
+++ b/packages/tanstack-query/src/__test__/fixtures.ts
@@ -103,6 +103,7 @@ export interface ActorSiblingsOverrideQueries {
     GetSiblings: ResourceQuery<
       EndpointParamsType<typeof TestEndpoints.Actor.Custom.GetSiblings>,
       undefined,
+      undefined,
       EndpointOutputType<typeof TestEndpoints.Actor.List>
     >;
   };

--- a/packages/tanstack-query/src/__typetests__/types.test-d.ts
+++ b/packages/tanstack-query/src/__typetests__/types.test-d.ts
@@ -1,3 +1,10 @@
+import {
+  type StreamOutputCodec,
+  type EndpointOutputType,
+  type IOTSCodec,
+  type ResourceEndpoints,
+  type MinimalEndpointInstance,
+} from '@ts-endpoint/core';
 import { type TestEndpoints } from '@ts-endpoint/test';
 import { describe, expectTypeOf, test } from 'vitest';
 import { type QueryProvider, type ResourceQueries, type ResourceQuery } from '../types.js';
@@ -6,6 +13,19 @@ describe('types', () => {
   test('ResourceQuery', () => {
     type RQ = ResourceQuery<
       { id: string },
+      {
+        filter: {
+          id: string;
+        };
+        pagination: {
+          page: number;
+          size: number;
+        };
+        sort: {
+          field: string;
+          order: 'asc' | 'desc';
+        };
+      },
       {
         filter: {
           id: string;
@@ -39,14 +59,7 @@ describe('types', () => {
       (typeof TestEndpoints)['Actor']['Custom']
     >;
     expectTypeOf<RR['get']['getKey']>().parameter(0).toEqualTypeOf<{ readonly id: string }>();
-    expectTypeOf<RR['list']['getKey']>().parameter(1).toEqualTypeOf<
-      | Partial<{
-          readonly _start: number;
-          readonly _end: number;
-          readonly ids: readonly string[];
-        }>
-      | undefined
-    >();
+    // list.getKey second parameter is the query (runtime type)
   });
 
   test('QueryProvider', () => {
@@ -55,5 +68,102 @@ describe('types', () => {
     type ActorGet = EndpointsQueryProvider['Actor']['get'];
 
     expectTypeOf<ActorGet['getKey']>().parameter(0).toEqualTypeOf<{ readonly id: string }>();
+  });
+
+  test('Stream output conversion', () => {
+    type StreamEndpointInstance = {
+      getPath: (i?: any) => string;
+      getStaticPath: (f?: any) => string;
+      Method: 'GET';
+      Input: undefined;
+      Output: StreamOutputCodec<string, string>;
+      Errors: undefined;
+    };
+
+    expectTypeOf<
+      EndpointOutputType<StreamEndpointInstance>
+    >().toEqualTypeOf<NodeJS.ReadableStream>();
+  });
+
+  test('Non-stream output conversion', () => {
+    // Use a real test endpoint for non-stream sanity check
+    expectTypeOf<EndpointOutputType<(typeof TestEndpoints)['Actor']['List']>>().toMatchTypeOf<{
+      data: unknown;
+    }>();
+  });
+
+  test('ResourceQueries with stream get', () => {
+    type StreamEndpointInstance = {
+      getPath: (i?: any) => string;
+      getStaticPath: (f?: any) => string;
+      Method: 'GET';
+      Input: undefined;
+      Output: StreamOutputCodec<string, string>;
+      Errors: undefined;
+    };
+
+    type NonStreamEndpointInstance = {
+      getPath: (i?: any) => string;
+      getStaticPath: (f?: any) => string;
+      Method: 'GET';
+      Input: undefined;
+      Output: IOTSCodec<{ data: string }, { data: string }>;
+      Errors: undefined;
+    };
+
+    type RQ = ResourceQueries<StreamEndpointInstance, NonStreamEndpointInstance, undefined>;
+
+    expectTypeOf<RQ['get']['fetch']>().returns.toEqualTypeOf<Promise<NodeJS.ReadableStream>>();
+    expectTypeOf<RQ['list']['fetch']>().returns.toEqualTypeOf<Promise<EndpointOutputType<NonStreamEndpointInstance>>>();
+  });
+
+  test('QueryProvider maps streams', () => {
+    type StreamEndpointInstance = {
+      getPath: (i?: any) => string;
+      getStaticPath: (f?: any) => string;
+      Method: 'GET';
+      Input: undefined;
+      Output: StreamOutputCodec<string, string>;
+      Errors: undefined;
+    };
+
+    type NonStreamEndpointInstance = {
+      getPath: (i?: any) => string;
+      getStaticPath: (f?: any) => string;
+      Method: 'GET';
+      Input: undefined;
+      Output: IOTSCodec<{ data: string }, { data: string }>;
+      Errors: undefined;
+    };
+
+    type ES = {
+      Actor: ResourceEndpoints<
+        StreamEndpointInstance & MinimalEndpointInstance,
+        NonStreamEndpointInstance & MinimalEndpointInstance,
+        NonStreamEndpointInstance & MinimalEndpointInstance,
+        NonStreamEndpointInstance & MinimalEndpointInstance,
+        NonStreamEndpointInstance & MinimalEndpointInstance,
+        {}
+      >;
+    };
+
+    type Provider = QueryProvider<ES>;
+    type ActorGet = Provider['Actor']['get'];
+
+    expectTypeOf<ActorGet['fetch']>().returns.toEqualTypeOf<Promise<NodeJS.ReadableStream>>();
+  });
+
+  test('List query accepts serialized values', () => {
+    type ActorList = ResourceQueries<
+      (typeof TestEndpoints)['Actor']['Get'],
+      (typeof TestEndpoints)['Actor']['List'],
+      (typeof TestEndpoints)['Actor']['Custom']
+    >['list'];
+
+    type ActorListFetch = ActorList['fetch'];
+
+    // ensure we can call the generated fetch with encoded (string) values
+    const fetchFn = null as unknown as ActorListFetch;
+    void fetchFn(undefined, { _end: '1', _start: '0', ids: ['1'] } as any);
   });
 });

--- a/packages/tanstack-query/src/__typetests__/types.test-d.ts
+++ b/packages/tanstack-query/src/__typetests__/types.test-d.ts
@@ -114,7 +114,9 @@ describe('types', () => {
     type RQ = ResourceQueries<StreamEndpointInstance, NonStreamEndpointInstance, undefined>;
 
     expectTypeOf<RQ['get']['fetch']>().returns.toEqualTypeOf<Promise<NodeJS.ReadableStream>>();
-    expectTypeOf<RQ['list']['fetch']>().returns.toEqualTypeOf<Promise<EndpointOutputType<NonStreamEndpointInstance>>>();
+    expectTypeOf<RQ['list']['fetch']>().returns.toEqualTypeOf<
+      Promise<EndpointOutputType<NonStreamEndpointInstance>>
+    >();
   });
 
   test('QueryProvider maps streams', () => {
@@ -143,7 +145,7 @@ describe('types', () => {
         NonStreamEndpointInstance & MinimalEndpointInstance,
         NonStreamEndpointInstance & MinimalEndpointInstance,
         NonStreamEndpointInstance & MinimalEndpointInstance,
-        {}
+        any
       >;
     };
 

--- a/packages/tanstack-query/src/types.ts
+++ b/packages/tanstack-query/src/types.ts
@@ -2,7 +2,6 @@ import { type UseQueryResult } from '@tanstack/react-query';
 import {
   type EndpointOutputType,
   type EndpointParamsType,
-  type EndpointQueryEncoded,
   type EndpointsMapType,
   type InferEndpointInstanceParams,
   type InferEndpointParams,
@@ -28,10 +27,10 @@ export type QueryPromiseFunction<P, Q, A> = (
   discrete?: boolean
 ) => Promise<A>;
 
-export interface ResourceQuery<P, Q, A> {
-  getKey: GetKeyFn<P, Q>;
-  fetch: QueryPromiseFunction<P, Q, A>;
-  useQuery: (p: P, q?: Q, discrete?: boolean, prefix?: string) => UseQueryResult<A, IOError>;
+export interface ResourceQuery<P, QK, QF, A> {
+  getKey: GetKeyFn<P, QK>;
+  fetch: QueryPromiseFunction<P, QF, A>;
+  useQuery: (p: P, q?: QF, discrete?: boolean, prefix?: string) => UseQueryResult<A, IOError>;
 }
 
 export interface ResourceQueries<
@@ -42,11 +41,13 @@ export interface ResourceQueries<
   get: ResourceQuery<
     EndpointParamsType<G>,
     PartialSerializedType<InferEndpointParams<G>['query']>,
+    PartialSerializedType<InferEndpointParams<G>['query']>,
     EndpointOutputType<G>
   >;
   list: ResourceQuery<
     EndpointParamsType<L>,
-    Partial<EndpointQueryEncoded<L>>,
+    any,
+    Partial<serializedType<InferEndpointParams<L>['query']>>,
     EndpointOutputType<L>
   >;
   Custom: CC extends Record<string, MinimalEndpointInstance>
@@ -55,6 +56,7 @@ export interface ResourceQueries<
           runtimeType<InferEndpointInstanceParams<CC[K]>['params']> extends never
             ? undefined
             : runtimeType<InferEndpointInstanceParams<CC[K]>['params']>,
+          Partial<serializedType<InferEndpointInstanceParams<CC[K]>['query']>>,
           Partial<serializedType<InferEndpointInstanceParams<CC[K]>['query']>>,
           EndpointOutputType<CC[K]>
         >;

--- a/packages/tanstack-query/tsconfig.build.json
+++ b/packages/tanstack-query/tsconfig.build.json
@@ -4,5 +4,5 @@
     "tsBuildInfoFile": "lib/.build.tsbuildinfo"
   },
   "include": ["src"],
-  "exclude": ["node_modules", "**/*.spec.*", "**/*.test-d.*", "**/*.samples.ts"]
+  "exclude": ["node_modules", "**/__test__/**", "**/*.spec.*", "**/*.test-d.*", "**/*.samples.ts"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ importers:
       '@eslint/js':
         specifier: ^9.24.0
         version: 9.24.0
+      '@types/node':
+        specifier: ^22
+        version: 22.14.1
       '@vitest/coverage-v8':
         specifier: ^4.0.18
         version: 4.0.18(vitest@4.0.18(@types/node@22.14.1)(jiti@2.4.2)(jsdom@26.1.0)(terser@5.39.0))
@@ -95,7 +98,7 @@ importers:
         version: 16.9.25(@types/react@18.3.20)
       '@vitejs/plugin-react':
         specifier: ^4.2.1
-        version: 4.4.0(vite@6.3.2(@types/node@22.14.1)(jiti@2.4.2)(terser@5.39.0))
+        version: 4.4.0(vite@6.3.2(@types/node@25.0.9)(jiti@2.4.2)(terser@5.39.0))
       fp-ts:
         specifier: ^2.8.2
         version: 2.16.10
@@ -110,7 +113,7 @@ importers:
         version: 5.8.3
       vite:
         specifier: ^6.3.1
-        version: 6.3.2(@types/node@22.14.1)(jiti@2.4.2)(terser@5.39.0)
+        version: 6.3.2(@types/node@25.0.9)(jiti@2.4.2)(terser@5.39.0)
 
   examples/react-express/server:
     dependencies:
@@ -124,8 +127,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/test
       express:
-        specifier: ^5.1.0
-        version: 5.1.0
+        specifier: ^5.2.1
+        version: 5.2.1
       fp-ts:
         specifier: ^2.8.2
         version: 2.16.10
@@ -134,8 +137,8 @@ importers:
         version: link:../shared
     devDependencies:
       '@types/express':
-        specifier: ^5.0.3
-        version: 5.0.3
+        specifier: ^5.0.6
+        version: 5.0.6
       typescript:
         specifier: ^5.8.2
         version: 5.8.3
@@ -194,14 +197,14 @@ importers:
         specifier: workspace:*
         version: link:../test
       '@types/express':
-        specifier: ^5.0.3
-        version: 5.0.3
+        specifier: ^5.0.6
+        version: 5.0.6
       effect:
         specifier: ^3.14.8
         version: 3.14.11
       express:
         specifier: ^5.1.0
-        version: 5.1.0
+        version: 5.2.1
       fp-ts:
         specifier: ^2.16.9
         version: 2.16.10
@@ -210,7 +213,7 @@ importers:
         version: 2.2.22(fp-ts@2.16.10)
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@types/node@22.14.1)(jiti@2.4.2)(jsdom@26.1.0)(terser@5.39.0)
+        version: 4.0.18(@types/node@25.0.9)(jiti@2.4.2)(jsdom@26.1.0)(terser@5.39.0)
 
   packages/http-client:
     dependencies:
@@ -241,7 +244,7 @@ importers:
         version: 26.1.0
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@types/node@22.14.1)(jiti@2.4.2)(jsdom@26.1.0)(terser@5.39.0)
+        version: 4.0.18(@types/node@25.0.9)(jiti@2.4.2)(jsdom@26.1.0)(terser@5.39.0)
 
   packages/react-admin:
     dependencies:
@@ -266,10 +269,10 @@ importers:
         version: 2.2.22(fp-ts@2.16.10)
       react-admin:
         specifier: ^5.7.1
-        version: 5.7.3(@mui/system@6.4.11(@emotion/react@11.14.0(@types/react@19.1.0)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.0)(react@19.1.0))(@types/react@19.1.0)(react@19.1.0))(@types/react@19.1.0)(react@19.1.0))(@mui/utils@6.4.9(@types/react@19.1.0)(react@19.1.0))(@types/react@19.1.0)(react-dom@19.1.0(react@19.1.0))(react-is@19.1.0)(react@19.1.0)
+        version: 5.7.3(@mui/system@6.4.11(@emotion/react@11.14.0(@types/react@19.2.9)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.2.9)(react@19.1.0))(@types/react@19.2.9)(react@19.1.0))(@types/react@19.2.9)(react@19.1.0))(@mui/utils@6.4.9(@types/react@19.2.9)(react@19.1.0))(@types/react@19.2.9)(react-dom@19.1.0(react@19.1.0))(react-is@19.1.0)(react@19.1.0)
       vitest-mock-extended:
         specifier: ^3.1.0
-        version: 3.1.0(typescript@5.8.3)(vitest@4.0.18(@types/node@22.14.1)(jiti@2.4.2)(jsdom@26.1.0)(terser@5.39.0))
+        version: 3.1.0(typescript@5.8.3)(vitest@4.0.18(@types/node@25.0.9)(jiti@2.4.2)(jsdom@26.1.0)(terser@5.39.0))
 
   packages/resource-client:
     dependencies:
@@ -297,10 +300,10 @@ importers:
         version: 2.2.22(fp-ts@2.16.10)
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@types/node@22.14.1)(jiti@2.4.2)(jsdom@26.1.0)(terser@5.39.0)
+        version: 4.0.18(@types/node@25.0.9)(jiti@2.4.2)(jsdom@26.1.0)(terser@5.39.0)
       vitest-mock-extended:
         specifier: ^3.1.0
-        version: 3.1.0(typescript@5.8.3)(vitest@4.0.18(@types/node@22.14.1)(jiti@2.4.2)(jsdom@26.1.0)(terser@5.39.0))
+        version: 3.1.0(typescript@5.8.3)(vitest@4.0.18(@types/node@25.0.9)(jiti@2.4.2)(jsdom@26.1.0)(terser@5.39.0))
 
   packages/tanstack-query:
     dependencies:
@@ -347,10 +350,10 @@ importers:
     dependencies:
       '@docusaurus/core':
         specifier: 3.7.0
-        version: 3.7.0(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+        version: 3.7.0(@mdx-js/react@3.1.0(@types/react@19.2.9)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
       '@docusaurus/preset-classic':
         specifier: 3.7.0
-        version: 3.7.0(@algolia/client-search@5.23.4)(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(@types/react@19.1.0)(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(typescript@5.8.3)
+        version: 3.7.0(@algolia/client-search@5.23.4)(@mdx-js/react@3.1.0(@types/react@19.2.9)(react@18.3.1))(@types/react@19.2.9)(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(typescript@5.8.3)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -1633,20 +1636,8 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/aix-ppc64@0.27.2':
-    resolution: {integrity: sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [aix]
-
   '@esbuild/android-arm64@0.25.1':
     resolution: {integrity: sha512-50tM0zCJW5kGqgG7fQ7IHvQOcAn9TKiVRuQ/lN0xR+T2lzEFvAi1ZcS8DiksFcEpf1t/GYOeOfCAgDHFpkiSmA==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [android]
-
-  '@esbuild/android-arm64@0.27.2':
-    resolution: {integrity: sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -1657,20 +1648,8 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-arm@0.27.2':
-    resolution: {integrity: sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==}
-    engines: {node: '>=18'}
-    cpu: [arm]
-    os: [android]
-
   '@esbuild/android-x64@0.25.1':
     resolution: {integrity: sha512-GCj6WfUtNldqUzYkN/ITtlhwQqGWu9S45vUXs7EIYf+7rCiiqH9bCloatO9VhxsL0Pji+PF4Lz2XXCES+Q8hDw==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [android]
-
-  '@esbuild/android-x64@0.27.2':
-    resolution: {integrity: sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -1681,20 +1660,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-arm64@0.27.2':
-    resolution: {integrity: sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [darwin]
-
   '@esbuild/darwin-x64@0.25.1':
     resolution: {integrity: sha512-hxVnwL2Dqs3fM1IWq8Iezh0cX7ZGdVhbTfnOy5uURtao5OIVCEyj9xIzemDi7sRvKsuSdtCAhMKarxqtlyVyfA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@esbuild/darwin-x64@0.27.2':
-    resolution: {integrity: sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -1705,20 +1672,8 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-arm64@0.27.2':
-    resolution: {integrity: sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [freebsd]
-
   '@esbuild/freebsd-x64@0.25.1':
     resolution: {integrity: sha512-0IZWLiTyz7nm0xuIs0q1Y3QWJC52R8aSXxe40VUxm6BB1RNmkODtW6LHvWRrGiICulcX7ZvyH6h5fqdLu4gkww==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-x64@0.27.2':
-    resolution: {integrity: sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -1729,20 +1684,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm64@0.27.2':
-    resolution: {integrity: sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [linux]
-
   '@esbuild/linux-arm@0.25.1':
     resolution: {integrity: sha512-NdKOhS4u7JhDKw9G3cY6sWqFcnLITn6SqivVArbzIaf3cemShqfLGHYMx8Xlm/lBit3/5d7kXvriTUGa5YViuQ==}
-    engines: {node: '>=18'}
-    cpu: [arm]
-    os: [linux]
-
-  '@esbuild/linux-arm@0.27.2':
-    resolution: {integrity: sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -1753,20 +1696,8 @@ packages:
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.27.2':
-    resolution: {integrity: sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [linux]
-
   '@esbuild/linux-loong64@0.25.1':
     resolution: {integrity: sha512-nGfornQj4dzcq5Vp835oM/o21UMlXzn79KobKlcs3Wz9smwiifknLy4xDCLUU0BWp7b/houtdrgUz7nOGnfIYg==}
-    engines: {node: '>=18'}
-    cpu: [loong64]
-    os: [linux]
-
-  '@esbuild/linux-loong64@0.27.2':
-    resolution: {integrity: sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -1777,20 +1708,8 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.27.2':
-    resolution: {integrity: sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==}
-    engines: {node: '>=18'}
-    cpu: [mips64el]
-    os: [linux]
-
   '@esbuild/linux-ppc64@0.25.1':
     resolution: {integrity: sha512-/6VBJOwUf3TdTvJZ82qF3tbLuWsscd7/1w+D9LH0W/SqUgM5/JJD0lrJ1fVIfZsqB6RFmLCe0Xz3fmZc3WtyVg==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [linux]
-
-  '@esbuild/linux-ppc64@0.27.2':
-    resolution: {integrity: sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -1801,20 +1720,8 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.27.2':
-    resolution: {integrity: sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==}
-    engines: {node: '>=18'}
-    cpu: [riscv64]
-    os: [linux]
-
   '@esbuild/linux-s390x@0.25.1':
     resolution: {integrity: sha512-cEECeLlJNfT8kZHqLarDBQso9a27o2Zd2AQ8USAEoGtejOrCYHNtKP8XQhMDJMtthdF4GBmjR2au3x1udADQQQ==}
-    engines: {node: '>=18'}
-    cpu: [s390x]
-    os: [linux]
-
-  '@esbuild/linux-s390x@0.27.2':
-    resolution: {integrity: sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -1825,20 +1732,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/linux-x64@0.27.2':
-    resolution: {integrity: sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [linux]
-
   '@esbuild/netbsd-arm64@0.25.1':
     resolution: {integrity: sha512-O96poM2XGhLtpTh+s4+nP7YCCAfb4tJNRVZHfIE7dgmax+yMP2WgMd2OecBuaATHKTHsLWHQeuaxMRnCsH8+5g==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [netbsd]
-
-  '@esbuild/netbsd-arm64@0.27.2':
-    resolution: {integrity: sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -1849,20 +1744,8 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.27.2':
-    resolution: {integrity: sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [netbsd]
-
   '@esbuild/openbsd-arm64@0.25.1':
     resolution: {integrity: sha512-Na9T3szbXezdzM/Kfs3GcRQNjHzM6GzFBeU1/6IV/npKP5ORtp9zbQjvkDJ47s6BCgaAZnnnu/cY1x342+MvZg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openbsd]
-
-  '@esbuild/openbsd-arm64@0.27.2':
-    resolution: {integrity: sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -1873,26 +1756,8 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.27.2':
-    resolution: {integrity: sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [openbsd]
-
-  '@esbuild/openharmony-arm64@0.27.2':
-    resolution: {integrity: sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openharmony]
-
   '@esbuild/sunos-x64@0.25.1':
     resolution: {integrity: sha512-2H3RUvcmULO7dIE5EWJH8eubZAI4xw54H1ilJnRNZdeo8dTADEZ21w6J22XBkXqGJbe0+wnNJtw3UXRoLJnFEg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [sunos]
-
-  '@esbuild/sunos-x64@0.27.2':
-    resolution: {integrity: sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
@@ -1903,32 +1768,14 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-arm64@0.27.2':
-    resolution: {integrity: sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [win32]
-
   '@esbuild/win32-ia32@0.25.1':
     resolution: {integrity: sha512-uOxSJCIcavSiT6UnBhBzE8wy3n0hOkJsBOzy7HDAuTDE++1DJMRRVCPGisULScHL+a/ZwdXPpXD3IyFKjA7K8A==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.27.2':
-    resolution: {integrity: sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [win32]
-
   '@esbuild/win32-x64@0.25.1':
     resolution: {integrity: sha512-Y1EQdcfwMSeQN/ujR5VayLOJ1BHaK+ssyk0AEzPjC+t1lITgsnccPqFjb6V+LsTp/9Iov4ysfjxLaGJ9RPtkVg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [win32]
-
-  '@esbuild/win32-x64@0.27.2':
-    resolution: {integrity: sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -2176,19 +2023,9 @@ packages:
   '@popperjs/core@2.11.8':
     resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
 
-  '@rollup/rollup-android-arm-eabi@4.37.0':
-    resolution: {integrity: sha512-l7StVw6WAa8l3vA1ov80jyetOAEo1FtHvZDbzXDO/02Sq/QVvqlHkYoFwDJPIMj0GKiistsBudfx5tGFnwYWDQ==}
-    cpu: [arm]
-    os: [android]
-
   '@rollup/rollup-android-arm-eabi@4.56.0':
     resolution: {integrity: sha512-LNKIPA5k8PF1+jAFomGe3qN3bbIgJe/IlpDBwuVjrDKrJhVWywgnJvflMt/zkbVNLFtF1+94SljYQS6e99klnw==}
     cpu: [arm]
-    os: [android]
-
-  '@rollup/rollup-android-arm64@4.37.0':
-    resolution: {integrity: sha512-6U3SlVyMxezt8Y+/iEBcbp945uZjJwjZimu76xoG7tO1av9VO691z8PkhzQ85ith2I8R2RddEPeSfcbyPfD4hA==}
-    cpu: [arm64]
     os: [android]
 
   '@rollup/rollup-android-arm64@4.56.0':
@@ -2196,19 +2033,9 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.37.0':
-    resolution: {integrity: sha512-+iTQ5YHuGmPt10NTzEyMPbayiNTcOZDWsbxZYR1ZnmLnZxG17ivrPSWFO9j6GalY0+gV3Jtwrrs12DBscxnlYA==}
-    cpu: [arm64]
-    os: [darwin]
-
   '@rollup/rollup-darwin-arm64@4.56.0':
     resolution: {integrity: sha512-EgxD1ocWfhoD6xSOeEEwyE7tDvwTgZc8Bss7wCWe+uc7wO8G34HHCUH+Q6cHqJubxIAnQzAsyUsClt0yFLu06w==}
     cpu: [arm64]
-    os: [darwin]
-
-  '@rollup/rollup-darwin-x64@4.37.0':
-    resolution: {integrity: sha512-m8W2UbxLDcmRKVjgl5J/k4B8d7qX2EcJve3Sut7YGrQoPtCIQGPH5AMzuFvYRWZi0FVS0zEY4c8uttPfX6bwYQ==}
-    cpu: [x64]
     os: [darwin]
 
   '@rollup/rollup-darwin-x64@4.56.0':
@@ -2216,19 +2043,9 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-freebsd-arm64@4.37.0':
-    resolution: {integrity: sha512-FOMXGmH15OmtQWEt174v9P1JqqhlgYge/bUjIbiVD1nI1NeJ30HYT9SJlZMqdo1uQFyt9cz748F1BHghWaDnVA==}
-    cpu: [arm64]
-    os: [freebsd]
-
   '@rollup/rollup-freebsd-arm64@4.56.0':
     resolution: {integrity: sha512-bof7fbIlvqsyv/DtaXSck4VYQ9lPtoWNFCB/JY4snlFuJREXfZnm+Ej6yaCHfQvofJDXLDMTVxWscVSuQvVWUQ==}
     cpu: [arm64]
-    os: [freebsd]
-
-  '@rollup/rollup-freebsd-x64@4.37.0':
-    resolution: {integrity: sha512-SZMxNttjPKvV14Hjck5t70xS3l63sbVwl98g3FlVVx2YIDmfUIy29jQrsw06ewEYQ8lQSuY9mpAPlmgRD2iSsA==}
-    cpu: [x64]
     os: [freebsd]
 
   '@rollup/rollup-freebsd-x64@4.56.0':
@@ -2236,18 +2053,8 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.37.0':
-    resolution: {integrity: sha512-hhAALKJPidCwZcj+g+iN+38SIOkhK2a9bqtJR+EtyxrKKSt1ynCBeqrQy31z0oWU6thRZzdx53hVgEbRkuI19w==}
-    cpu: [arm]
-    os: [linux]
-
   '@rollup/rollup-linux-arm-gnueabihf@4.56.0':
     resolution: {integrity: sha512-E8jKK87uOvLrrLN28jnAAAChNq5LeCd2mGgZF+fGF5D507WlG/Noct3lP/QzQ6MrqJ5BCKNwI9ipADB6jyiq2A==}
-    cpu: [arm]
-    os: [linux]
-
-  '@rollup/rollup-linux-arm-musleabihf@4.37.0':
-    resolution: {integrity: sha512-jUb/kmn/Gd8epbHKEqkRAxq5c2EwRt0DqhSGWjPFxLeFvldFdHQs/n8lQ9x85oAeVb6bHcS8irhTJX2FCOd8Ag==}
     cpu: [arm]
     os: [linux]
 
@@ -2256,18 +2063,8 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-gnu@4.37.0':
-    resolution: {integrity: sha512-oNrJxcQT9IcbcmKlkF+Yz2tmOxZgG9D9GRq+1OE6XCQwCVwxixYAa38Z8qqPzQvzt1FCfmrHX03E0pWoXm1DqA==}
-    cpu: [arm64]
-    os: [linux]
-
   '@rollup/rollup-linux-arm64-gnu@4.56.0':
     resolution: {integrity: sha512-uQVoKkrC1KGEV6udrdVahASIsaF8h7iLG0U0W+Xn14ucFwi6uS539PsAr24IEF9/FoDtzMeeJXJIBo5RkbNWvQ==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@rollup/rollup-linux-arm64-musl@4.37.0':
-    resolution: {integrity: sha512-pfxLBMls+28Ey2enpX3JvjEjaJMBX5XlPCZNGxj4kdJyHduPBXtxYeb8alo0a7bqOoWZW2uKynhHxF/MWoHaGQ==}
     cpu: [arm64]
     os: [linux]
 
@@ -2286,16 +2083,6 @@ packages:
     cpu: [loong64]
     os: [linux]
 
-  '@rollup/rollup-linux-loongarch64-gnu@4.37.0':
-    resolution: {integrity: sha512-yCE0NnutTC/7IGUq/PUHmoeZbIwq3KRh02e9SfFh7Vmc1Z7atuJRYWhRME5fKgT8aS20mwi1RyChA23qSyRGpA==}
-    cpu: [loong64]
-    os: [linux]
-
-  '@rollup/rollup-linux-powerpc64le-gnu@4.37.0':
-    resolution: {integrity: sha512-NxcICptHk06E2Lh3a4Pu+2PEdZ6ahNHuK7o6Np9zcWkrBMuv21j10SQDJW3C9Yf/A/P7cutWoC/DptNLVsZ0VQ==}
-    cpu: [ppc64]
-    os: [linux]
-
   '@rollup/rollup-linux-ppc64-gnu@4.56.0':
     resolution: {integrity: sha512-iNFTluqgdoQC7AIE8Q34R3AuPrJGJirj5wMUErxj22deOcY7XwZRaqYmB6ZKFHoVGqRcRd0mqO+845jAibKCkw==}
     cpu: [ppc64]
@@ -2306,18 +2093,8 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.37.0':
-    resolution: {integrity: sha512-PpWwHMPCVpFZLTfLq7EWJWvrmEuLdGn1GMYcm5MV7PaRgwCEYJAwiN94uBuZev0/J/hFIIJCsYw4nLmXA9J7Pw==}
-    cpu: [riscv64]
-    os: [linux]
-
   '@rollup/rollup-linux-riscv64-gnu@4.56.0':
     resolution: {integrity: sha512-in+v6wiHdzzVhYKXIk5U74dEZHdKN9KH0Q4ANHOTvyXPG41bajYRsy7a8TPKbYPl34hU7PP7hMVHRvv/5aCSew==}
-    cpu: [riscv64]
-    os: [linux]
-
-  '@rollup/rollup-linux-riscv64-musl@4.37.0':
-    resolution: {integrity: sha512-DTNwl6a3CfhGTAOYZ4KtYbdS8b+275LSLqJVJIrPa5/JuIufWWZ/QFvkxp52gpmguN95eujrM68ZG+zVxa8zHA==}
     cpu: [riscv64]
     os: [linux]
 
@@ -2326,28 +2103,13 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-s390x-gnu@4.37.0':
-    resolution: {integrity: sha512-hZDDU5fgWvDdHFuExN1gBOhCuzo/8TMpidfOR+1cPZJflcEzXdCy1LjnklQdW8/Et9sryOPJAKAQRw8Jq7Tg+A==}
-    cpu: [s390x]
-    os: [linux]
-
   '@rollup/rollup-linux-s390x-gnu@4.56.0':
     resolution: {integrity: sha512-zhLLJx9nQPu7wezbxt2ut+CI4YlXi68ndEve16tPc/iwoylWS9B3FxpLS2PkmfYgDQtosah07Mj9E0khc3Y+vQ==}
     cpu: [s390x]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-gnu@4.37.0':
-    resolution: {integrity: sha512-pKivGpgJM5g8dwj0ywBwe/HeVAUSuVVJhUTa/URXjxvoyTT/AxsLTAbkHkDHG7qQxLoW2s3apEIl26uUe08LVQ==}
-    cpu: [x64]
-    os: [linux]
-
   '@rollup/rollup-linux-x64-gnu@4.56.0':
     resolution: {integrity: sha512-MVC6UDp16ZSH7x4rtuJPAEoE1RwS8N4oK9DLHy3FTEdFoUTCFVzMfJl/BVJ330C+hx8FfprA5Wqx4FhZXkj2Kw==}
-    cpu: [x64]
-    os: [linux]
-
-  '@rollup/rollup-linux-x64-musl@4.37.0':
-    resolution: {integrity: sha512-E2lPrLKE8sQbY/2bEkVTGDEk4/49UYRVWgj90MY8yPjpnGBQ+Xi1Qnr7b7UIWw1NOggdFQFOLZ8+5CzCiz143w==}
     cpu: [x64]
     os: [linux]
 
@@ -2366,19 +2128,9 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
-  '@rollup/rollup-win32-arm64-msvc@4.37.0':
-    resolution: {integrity: sha512-Jm7biMazjNzTU4PrQtr7VS8ibeys9Pn29/1bm4ph7CP2kf21950LgN+BaE2mJ1QujnvOc6p54eWWiVvn05SOBg==}
-    cpu: [arm64]
-    os: [win32]
-
   '@rollup/rollup-win32-arm64-msvc@4.56.0':
     resolution: {integrity: sha512-kbFsOObXp3LBULg1d3JIUQMa9Kv4UitDmpS+k0tinPBz3watcUiV2/LUDMMucA6pZO3WGE27P7DsfaN54l9ing==}
     cpu: [arm64]
-    os: [win32]
-
-  '@rollup/rollup-win32-ia32-msvc@4.37.0':
-    resolution: {integrity: sha512-e3/1SFm1OjefWICB2Ucstg2dxYDkDTZGDYgwufcbsxTHyqQps1UQf33dFEChBNmeSsTOyrjw2JJq0zbG5GF6RA==}
-    cpu: [ia32]
     os: [win32]
 
   '@rollup/rollup-win32-ia32-msvc@4.56.0':
@@ -2388,11 +2140,6 @@ packages:
 
   '@rollup/rollup-win32-x64-gnu@4.56.0':
     resolution: {integrity: sha512-FeCnkPCTHQJFbiGG49KjV5YGW/8b9rrXAM2Mz2kiIoktq2qsJxRD5giEMEOD2lPdgs72upzefaUvS+nc8E3UzQ==}
-    cpu: [x64]
-    os: [win32]
-
-  '@rollup/rollup-win32-x64-msvc@4.37.0':
-    resolution: {integrity: sha512-LWbXUBwn/bcLx2sSsqy7pK5o+Nr+VCoRoAohfJ5C/aBio9nfJmGQqHAhU6pwxV/RmyTk5AqdySma7uwWGlmeuA==}
     cpu: [x64]
     os: [win32]
 
@@ -2599,9 +2346,6 @@ packages:
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
 
-  '@types/estree@1.0.6':
-    resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
-
   '@types/estree@1.0.7':
     resolution: {integrity: sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==}
 
@@ -2614,11 +2358,11 @@ packages:
   '@types/express-serve-static-core@5.0.6':
     resolution: {integrity: sha512-3xhRnjJPkULekpSzgtoNYYcTWgEZkp4myc+Saevii5JPnHNvHMRlBSHDbs7Bh1iPPoVTERHEZXyhyLbMEsExsA==}
 
-  '@types/express@4.17.21':
-    resolution: {integrity: sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==}
+  '@types/express@4.17.25':
+    resolution: {integrity: sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==}
 
-  '@types/express@5.0.3':
-    resolution: {integrity: sha512-wGA0NX93b19/dZC1J18tKWVIYWyyF2ZjT9vin/NRu0qzzvfVzWjs04iq2rQ3H65vCTQYlRqs3YHfY7zjdV+9Kw==}
+  '@types/express@5.0.6':
+    resolution: {integrity: sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==}
 
   '@types/gtag.js@0.0.12':
     resolution: {integrity: sha512-YQV9bUsemkzG81Ea295/nF/5GijnD2Af7QhEofh7xu+kvCN6RdodgNwwGWXB5GMI3NoyvQo0odNctoH/qLMIpg==}
@@ -2635,8 +2379,8 @@ packages:
   '@types/http-cache-semantics@4.0.4':
     resolution: {integrity: sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==}
 
-  '@types/http-errors@2.0.4':
-    resolution: {integrity: sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==}
+  '@types/http-errors@2.0.5':
+    resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
 
   '@types/http-proxy@1.17.16':
     resolution: {integrity: sha512-sdWoUajOB1cd0A8cRRQ1cfyWNbmFKLAqBB89Y8x5iYyG/mkJHc0YUH8pdWBy2omi9qtCpiIgGjuwO0dQST2l5w==}
@@ -2677,6 +2421,9 @@ packages:
   '@types/node@22.14.1':
     resolution: {integrity: sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw==}
 
+  '@types/node@25.0.9':
+    resolution: {integrity: sha512-/rpCXHlCWeqClNBwUhDcusJxXYDjZTyE8v5oTO7WbL8eij2nKhUeU89/6xgjU7N4/Vh3He0BtyhJdQbDyhiXAw==}
+
   '@types/parse-json@4.0.2':
     resolution: {integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==}
 
@@ -2714,8 +2461,8 @@ packages:
   '@types/react@18.3.20':
     resolution: {integrity: sha512-IPaCZN7PShZK/3t6Q87pfTkRm6oLTd4vztyoj+cbHUF1g3FfVb2tFIL79uCRKEfv16AhqDMBywP2VW3KIZUvcg==}
 
-  '@types/react@19.1.0':
-    resolution: {integrity: sha512-UaicktuQI+9UKyA4njtDOGBD/67t8YEBt2xdfqu8+gP9hqPUPsiXlNPcpS2gVdjmis5GKPG3fCxbQLVgxsQZ8w==}
+  '@types/react@19.2.9':
+    resolution: {integrity: sha512-Lpo8kgb/igvMIPeNV2rsYKTgaORYdO1XGVZ4Qz3akwOj0ySGYMPlQWa8BaLn0G63D1aSaAQ5ldR06wCpChQCjA==}
 
   '@types/retry@0.12.0':
     resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
@@ -2729,8 +2476,11 @@ packages:
   '@types/serve-index@1.9.4':
     resolution: {integrity: sha512-qLpGZ/c2fhSs5gnYsQxtDEq3Oy8SXPClIXkW5ghvAvsNuVSA8k+gCONcUCS/UjLEYvYps+e8uBtfgXgvhwfNug==}
 
-  '@types/serve-static@1.15.7':
-    resolution: {integrity: sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==}
+  '@types/serve-static@1.15.10':
+    resolution: {integrity: sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==}
+
+  '@types/serve-static@2.2.0':
+    resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
 
   '@types/sockjs@0.3.36':
     resolution: {integrity: sha512-MK9V6NzAS1+Ud7JV9lJLFqW85VbC9dq3LmwZCuBe4wBDgKC0Kj/jd8Xl+nSviU+Qc3+m7umHHyHg//2KSa0a0Q==}
@@ -3224,12 +2974,12 @@ packages:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
 
-  body-parser@1.20.3:
-    resolution: {integrity: sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==}
+  body-parser@1.20.4:
+    resolution: {integrity: sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
-  body-parser@2.2.0:
-    resolution: {integrity: sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==}
+  body-parser@2.2.2:
+    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
 
   bonjour-service@1.3.0:
@@ -3766,6 +3516,15 @@ packages:
       supports-color:
         optional: true
 
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
   decimal.js@10.5.0:
     resolution: {integrity: sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==}
 
@@ -4016,11 +3775,6 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  esbuild@0.27.2:
-    resolution: {integrity: sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==}
-    engines: {node: '>=18'}
-    hasBin: true
-
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
@@ -4232,12 +3986,12 @@ packages:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
-  express@4.21.2:
-    resolution: {integrity: sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==}
+  express@4.22.1:
+    resolution: {integrity: sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==}
     engines: {node: '>= 0.10.0'}
 
-  express@5.1.0:
-    resolution: {integrity: sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==}
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
     engines: {node: '>= 18'}
 
   extend-shallow@2.0.1:
@@ -4492,6 +4246,7 @@ packages:
   git-raw-commits@4.0.0:
     resolution: {integrity: sha512-ICsMM1Wk8xSGMowkOmPrzo2Fgmfo4bMHLNX6ytHjajRJUqvHOw/TFapQ+QG75c3X/tTDDhOSRPGC52dDbNM8FQ==}
     engines: {node: '>=16'}
+    deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
     hasBin: true
 
   github-slugger@1.5.0:
@@ -4510,7 +4265,7 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   global-directory@4.0.1:
     resolution: {integrity: sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==}
@@ -4703,6 +4458,10 @@ packages:
     resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
     engines: {node: '>= 0.8'}
 
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+
   http-parser-js@0.5.10:
     resolution: {integrity: sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==}
 
@@ -4746,6 +4505,10 @@ packages:
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
+  iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
 
   icss-utils@5.1.0:
@@ -6384,12 +6147,12 @@ packages:
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
 
-  qs@6.13.0:
-    resolution: {integrity: sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==}
-    engines: {node: '>=0.6'}
-
   qs@6.14.0:
     resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
+    engines: {node: '>=0.6'}
+
+  qs@6.14.1:
+    resolution: {integrity: sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==}
     engines: {node: '>=0.6'}
 
   query-string@7.1.3:
@@ -6447,13 +6210,13 @@ packages:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
 
-  raw-body@2.5.2:
-    resolution: {integrity: sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==}
+  raw-body@2.5.3:
+    resolution: {integrity: sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==}
     engines: {node: '>= 0.8'}
 
-  raw-body@3.0.0:
-    resolution: {integrity: sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==}
-    engines: {node: '>= 0.8'}
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
@@ -6758,11 +6521,6 @@ packages:
     deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
-  rollup@4.37.0:
-    resolution: {integrity: sha512-iAtQy/L4QFU+rTJ1YUjXqJOJzuwEghqWzCEYD2FEghT7Gsy1VdABntrO4CLopA5IkflTyqNiLNwPcOJ3S7UKLg==}
-    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
-    hasBin: true
-
   rollup@4.56.0:
     resolution: {integrity: sha512-9FwVqlgUHzbXtDg9RCMgodF3Ua4Na6Gau+Sdt9vyCN4RhHfVKX2DCHy3BjMLTDd47ITDhYAnTwGulWTblJSDLg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -7039,6 +6797,10 @@ packages:
 
   statuses@2.0.1:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
+    engines: {node: '>= 0.8'}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
 
   std-env@3.10.0:
@@ -7352,6 +7114,9 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
   unicode-canonical-property-names-ecmascript@2.0.1:
     resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}
     engines: {node: '>=4'}
@@ -7487,46 +7252,6 @@ packages:
       sass-embedded: '*'
       stylus: '*'
       sugarss: '*'
-      terser: ^5.16.0
-      tsx: ^4.8.1
-      yaml: ^2.4.2
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      jiti:
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      sass-embedded:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-      tsx:
-        optional: true
-      yaml:
-        optional: true
-
-  vite@7.3.1:
-    resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': ^20.19.0 || >=22.12.0
-      jiti: '>=1.21.0'
-      less: ^4.0.0
-      lightningcss: ^1.21.0
-      sass: ^1.70.0
-      sass-embedded: ^1.70.0
-      stylus: '>=0.54.8'
-      sugarss: ^5.0.0
       terser: ^5.16.0
       tsx: ^4.8.1
       yaml: ^2.4.2
@@ -8016,7 +7741,7 @@ snapshots:
       '@babel/core': 7.26.10
       '@babel/helper-compilation-targets': 7.27.0
       '@babel/helper-plugin-utils': 7.26.5
-      debug: 4.4.0
+      debug: 4.4.3
       lodash.debounce: 4.0.8
       resolve: 1.22.10
     transitivePeerDependencies:
@@ -9078,14 +8803,14 @@ snapshots:
 
   '@docsearch/css@3.9.0': {}
 
-  '@docsearch/react@3.9.0(@algolia/client-search@5.23.4)(@types/react@19.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)':
+  '@docsearch/react@3.9.0(@algolia/client-search@5.23.4)(@types/react@19.2.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)':
     dependencies:
       '@algolia/autocomplete-core': 1.17.9(@algolia/client-search@5.23.4)(algoliasearch@5.23.4)(search-insights@2.17.3)
       '@algolia/autocomplete-preset-algolia': 1.17.9(@algolia/client-search@5.23.4)(algoliasearch@5.23.4)
       '@docsearch/css': 3.9.0
       algoliasearch: 5.23.4
     optionalDependencies:
-      '@types/react': 19.1.0
+      '@types/react': 19.2.9
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       search-insights: 2.17.3
@@ -9164,7 +8889,7 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/core@3.7.0(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)':
+  '@docusaurus/core@3.7.0(@mdx-js/react@3.1.0(@types/react@19.2.9)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)':
     dependencies:
       '@docusaurus/babel': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/bundler': 3.7.0(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
@@ -9173,7 +8898,7 @@ snapshots:
       '@docusaurus/utils': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils-common': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils-validation': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@mdx-js/react': 3.1.0(@types/react@19.1.0)(react@18.3.1)
+      '@mdx-js/react': 3.1.0(@types/react@19.2.9)(react@18.3.1)
       boxen: 6.2.1
       chalk: 4.1.2
       chokidar: 3.6.0
@@ -9233,9 +8958,9 @@ snapshots:
 
   '@docusaurus/cssnano-preset@3.7.0':
     dependencies:
-      cssnano-preset-advanced: 6.1.2(postcss@8.5.3)
-      postcss: 8.5.3
-      postcss-sort-media-queries: 5.2.0(postcss@8.5.3)
+      cssnano-preset-advanced: 6.1.2(postcss@8.5.6)
+      postcss: 8.5.6
+      postcss-sort-media-queries: 5.2.0(postcss@8.5.6)
       tslib: 2.8.1
 
   '@docusaurus/logger@3.7.0':
@@ -9298,13 +9023,13 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/plugin-content-blog@3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3))(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)':
+  '@docusaurus/plugin-content-blog@3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.2.9)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3))(@mdx-js/react@3.1.0(@types/react@19.2.9)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)':
     dependencies:
-      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.2.9)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
       '@docusaurus/logger': 3.7.0
       '@docusaurus/mdx-loader': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/plugin-content-docs': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
-      '@docusaurus/theme-common': 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/plugin-content-docs': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.2.9)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+      '@docusaurus/theme-common': 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.2.9)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/types': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils-common': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -9342,13 +9067,13 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)':
+  '@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.2.9)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)':
     dependencies:
-      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.2.9)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
       '@docusaurus/logger': 3.7.0
       '@docusaurus/mdx-loader': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/module-type-aliases': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/theme-common': 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/theme-common': 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.2.9)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/types': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils-common': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -9384,9 +9109,9 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-content-pages@3.7.0(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)':
+  '@docusaurus/plugin-content-pages@3.7.0(@mdx-js/react@3.1.0(@types/react@19.2.9)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)':
     dependencies:
-      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.2.9)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
       '@docusaurus/mdx-loader': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/types': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -9417,9 +9142,9 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-debug@3.7.0(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)':
+  '@docusaurus/plugin-debug@3.7.0(@mdx-js/react@3.1.0(@types/react@19.2.9)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)':
     dependencies:
-      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.2.9)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
       '@docusaurus/types': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       fs-extra: 11.3.0
@@ -9448,9 +9173,9 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-google-analytics@3.7.0(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)':
+  '@docusaurus/plugin-google-analytics@3.7.0(@mdx-js/react@3.1.0(@types/react@19.2.9)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)':
     dependencies:
-      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.2.9)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
       '@docusaurus/types': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils-validation': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
@@ -9477,9 +9202,9 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-google-gtag@3.7.0(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)':
+  '@docusaurus/plugin-google-gtag@3.7.0(@mdx-js/react@3.1.0(@types/react@19.2.9)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)':
     dependencies:
-      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.2.9)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
       '@docusaurus/types': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils-validation': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/gtag.js': 0.0.12
@@ -9507,9 +9232,9 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-google-tag-manager@3.7.0(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)':
+  '@docusaurus/plugin-google-tag-manager@3.7.0(@mdx-js/react@3.1.0(@types/react@19.2.9)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)':
     dependencies:
-      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.2.9)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
       '@docusaurus/types': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils-validation': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
@@ -9536,9 +9261,9 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-sitemap@3.7.0(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)':
+  '@docusaurus/plugin-sitemap@3.7.0(@mdx-js/react@3.1.0(@types/react@19.2.9)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)':
     dependencies:
-      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.2.9)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
       '@docusaurus/logger': 3.7.0
       '@docusaurus/types': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -9570,9 +9295,9 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-svgr@3.7.0(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)':
+  '@docusaurus/plugin-svgr@3.7.0(@mdx-js/react@3.1.0(@types/react@19.2.9)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)':
     dependencies:
-      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.2.9)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
       '@docusaurus/types': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils-validation': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -9603,21 +9328,21 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/preset-classic@3.7.0(@algolia/client-search@5.23.4)(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(@types/react@19.1.0)(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(typescript@5.8.3)':
+  '@docusaurus/preset-classic@3.7.0(@algolia/client-search@5.23.4)(@mdx-js/react@3.1.0(@types/react@19.2.9)(react@18.3.1))(@types/react@19.2.9)(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(typescript@5.8.3)':
     dependencies:
-      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
-      '@docusaurus/plugin-content-blog': 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3))(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
-      '@docusaurus/plugin-content-docs': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
-      '@docusaurus/plugin-content-pages': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
-      '@docusaurus/plugin-debug': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
-      '@docusaurus/plugin-google-analytics': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
-      '@docusaurus/plugin-google-gtag': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
-      '@docusaurus/plugin-google-tag-manager': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
-      '@docusaurus/plugin-sitemap': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
-      '@docusaurus/plugin-svgr': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
-      '@docusaurus/theme-classic': 3.7.0(@types/react@19.1.0)(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
-      '@docusaurus/theme-common': 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/theme-search-algolia': 3.7.0(@algolia/client-search@5.23.4)(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(@types/react@19.1.0)(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(typescript@5.8.3)
+      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.2.9)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+      '@docusaurus/plugin-content-blog': 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.2.9)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3))(@mdx-js/react@3.1.0(@types/react@19.2.9)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+      '@docusaurus/plugin-content-docs': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.2.9)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+      '@docusaurus/plugin-content-pages': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.2.9)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+      '@docusaurus/plugin-debug': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.2.9)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+      '@docusaurus/plugin-google-analytics': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.2.9)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+      '@docusaurus/plugin-google-gtag': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.2.9)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+      '@docusaurus/plugin-google-tag-manager': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.2.9)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+      '@docusaurus/plugin-sitemap': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.2.9)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+      '@docusaurus/plugin-svgr': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.2.9)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+      '@docusaurus/theme-classic': 3.7.0(@types/react@19.2.9)(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+      '@docusaurus/theme-common': 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.2.9)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/theme-search-algolia': 3.7.0(@algolia/client-search@5.23.4)(@mdx-js/react@3.1.0(@types/react@19.2.9)(react@18.3.1))(@types/react@19.2.9)(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(typescript@5.8.3)
       '@docusaurus/types': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -9650,22 +9375,22 @@ snapshots:
       '@types/react': 18.3.20
       react: 18.3.1
 
-  '@docusaurus/theme-classic@3.7.0(@types/react@19.1.0)(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)':
+  '@docusaurus/theme-classic@3.7.0(@types/react@19.2.9)(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)':
     dependencies:
-      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.2.9)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
       '@docusaurus/logger': 3.7.0
       '@docusaurus/mdx-loader': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/module-type-aliases': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/plugin-content-blog': 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3))(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
-      '@docusaurus/plugin-content-docs': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
-      '@docusaurus/plugin-content-pages': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
-      '@docusaurus/theme-common': 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/plugin-content-blog': 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.2.9)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3))(@mdx-js/react@3.1.0(@types/react@19.2.9)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+      '@docusaurus/plugin-content-docs': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.2.9)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+      '@docusaurus/plugin-content-pages': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.2.9)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+      '@docusaurus/theme-common': 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.2.9)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/theme-translations': 3.7.0
       '@docusaurus/types': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils-common': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils-validation': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@mdx-js/react': 3.1.0(@types/react@19.1.0)(react@18.3.1)
+      '@mdx-js/react': 3.1.0(@types/react@19.2.9)(react@18.3.1)
       clsx: 2.1.1
       copy-text-to-clipboard: 3.2.0
       infima: 0.2.0-alpha.45
@@ -9701,15 +9426,15 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/theme-common@3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@docusaurus/theme-common@3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.2.9)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@docusaurus/mdx-loader': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/module-type-aliases': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/plugin-content-docs': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+      '@docusaurus/plugin-content-docs': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.2.9)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
       '@docusaurus/utils': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils-common': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/history': 4.7.11
-      '@types/react': 18.3.20
+      '@types/react': 19.2.9
       '@types/react-router-config': 5.0.11
       clsx: 2.1.1
       parse-numeric-range: 1.3.0
@@ -9726,13 +9451,13 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/theme-search-algolia@3.7.0(@algolia/client-search@5.23.4)(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(@types/react@19.1.0)(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(typescript@5.8.3)':
+  '@docusaurus/theme-search-algolia@3.7.0(@algolia/client-search@5.23.4)(@mdx-js/react@3.1.0(@types/react@19.2.9)(react@18.3.1))(@types/react@19.2.9)(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(typescript@5.8.3)':
     dependencies:
-      '@docsearch/react': 3.9.0(@algolia/client-search@5.23.4)(@types/react@19.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)
-      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+      '@docsearch/react': 3.9.0(@algolia/client-search@5.23.4)(@types/react@19.2.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)
+      '@docusaurus/core': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.2.9)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
       '@docusaurus/logger': 3.7.0
-      '@docusaurus/plugin-content-docs': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
-      '@docusaurus/theme-common': 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/plugin-content-docs': 3.7.0(@mdx-js/react@3.1.0(@types/react@19.2.9)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+      '@docusaurus/theme-common': 3.7.0(@docusaurus/plugin-content-docs@3.7.0(@mdx-js/react@3.1.0(@types/react@19.2.9)(react@18.3.1))(acorn@8.14.1)(eslint@9.24.0(jiti@2.4.2))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3))(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/theme-translations': 3.7.0
       '@docusaurus/utils': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/utils-validation': 3.7.0(acorn@8.14.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -9881,7 +9606,7 @@ snapshots:
   '@emotion/babel-plugin@11.13.5':
     dependencies:
       '@babel/helper-module-imports': 7.25.9
-      '@babel/runtime': 7.27.0
+      '@babel/runtime': 7.28.6
       '@emotion/hash': 0.9.2
       '@emotion/memoize': 0.9.0
       '@emotion/serialize': 1.3.3
@@ -9910,7 +9635,7 @@ snapshots:
 
   '@emotion/memoize@0.9.0': {}
 
-  '@emotion/react@11.14.0(@types/react@19.1.0)(react@19.1.0)':
+  '@emotion/react@11.14.0(@types/react@19.2.9)(react@19.1.0)':
     dependencies:
       '@babel/runtime': 7.27.0
       '@emotion/babel-plugin': 11.13.5
@@ -9922,7 +9647,7 @@ snapshots:
       hoist-non-react-statics: 3.3.2
       react: 19.1.0
     optionalDependencies:
-      '@types/react': 19.1.0
+      '@types/react': 19.2.9
     transitivePeerDependencies:
       - supports-color
 
@@ -9936,18 +9661,18 @@ snapshots:
 
   '@emotion/sheet@1.4.0': {}
 
-  '@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.0)(react@19.1.0))(@types/react@19.1.0)(react@19.1.0)':
+  '@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.2.9)(react@19.1.0))(@types/react@19.2.9)(react@19.1.0)':
     dependencies:
       '@babel/runtime': 7.27.0
       '@emotion/babel-plugin': 11.13.5
       '@emotion/is-prop-valid': 1.3.1
-      '@emotion/react': 11.14.0(@types/react@19.1.0)(react@19.1.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.9)(react@19.1.0)
       '@emotion/serialize': 1.3.3
       '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@19.1.0)
       '@emotion/utils': 1.4.2
       react: 19.1.0
     optionalDependencies:
-      '@types/react': 19.1.0
+      '@types/react': 19.2.9
     transitivePeerDependencies:
       - supports-color
 
@@ -9964,154 +9689,76 @@ snapshots:
   '@esbuild/aix-ppc64@0.25.1':
     optional: true
 
-  '@esbuild/aix-ppc64@0.27.2':
-    optional: true
-
   '@esbuild/android-arm64@0.25.1':
-    optional: true
-
-  '@esbuild/android-arm64@0.27.2':
     optional: true
 
   '@esbuild/android-arm@0.25.1':
     optional: true
 
-  '@esbuild/android-arm@0.27.2':
-    optional: true
-
   '@esbuild/android-x64@0.25.1':
-    optional: true
-
-  '@esbuild/android-x64@0.27.2':
     optional: true
 
   '@esbuild/darwin-arm64@0.25.1':
     optional: true
 
-  '@esbuild/darwin-arm64@0.27.2':
-    optional: true
-
   '@esbuild/darwin-x64@0.25.1':
-    optional: true
-
-  '@esbuild/darwin-x64@0.27.2':
     optional: true
 
   '@esbuild/freebsd-arm64@0.25.1':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.27.2':
-    optional: true
-
   '@esbuild/freebsd-x64@0.25.1':
-    optional: true
-
-  '@esbuild/freebsd-x64@0.27.2':
     optional: true
 
   '@esbuild/linux-arm64@0.25.1':
     optional: true
 
-  '@esbuild/linux-arm64@0.27.2':
-    optional: true
-
   '@esbuild/linux-arm@0.25.1':
-    optional: true
-
-  '@esbuild/linux-arm@0.27.2':
     optional: true
 
   '@esbuild/linux-ia32@0.25.1':
     optional: true
 
-  '@esbuild/linux-ia32@0.27.2':
-    optional: true
-
   '@esbuild/linux-loong64@0.25.1':
-    optional: true
-
-  '@esbuild/linux-loong64@0.27.2':
     optional: true
 
   '@esbuild/linux-mips64el@0.25.1':
     optional: true
 
-  '@esbuild/linux-mips64el@0.27.2':
-    optional: true
-
   '@esbuild/linux-ppc64@0.25.1':
-    optional: true
-
-  '@esbuild/linux-ppc64@0.27.2':
     optional: true
 
   '@esbuild/linux-riscv64@0.25.1':
     optional: true
 
-  '@esbuild/linux-riscv64@0.27.2':
-    optional: true
-
   '@esbuild/linux-s390x@0.25.1':
-    optional: true
-
-  '@esbuild/linux-s390x@0.27.2':
     optional: true
 
   '@esbuild/linux-x64@0.25.1':
     optional: true
 
-  '@esbuild/linux-x64@0.27.2':
-    optional: true
-
   '@esbuild/netbsd-arm64@0.25.1':
-    optional: true
-
-  '@esbuild/netbsd-arm64@0.27.2':
     optional: true
 
   '@esbuild/netbsd-x64@0.25.1':
     optional: true
 
-  '@esbuild/netbsd-x64@0.27.2':
-    optional: true
-
   '@esbuild/openbsd-arm64@0.25.1':
-    optional: true
-
-  '@esbuild/openbsd-arm64@0.27.2':
     optional: true
 
   '@esbuild/openbsd-x64@0.25.1':
     optional: true
 
-  '@esbuild/openbsd-x64@0.27.2':
-    optional: true
-
-  '@esbuild/openharmony-arm64@0.27.2':
-    optional: true
-
   '@esbuild/sunos-x64@0.25.1':
-    optional: true
-
-  '@esbuild/sunos-x64@0.27.2':
     optional: true
 
   '@esbuild/win32-arm64@0.25.1':
     optional: true
 
-  '@esbuild/win32-arm64@0.27.2':
-    optional: true
-
   '@esbuild/win32-ia32@0.25.1':
     optional: true
 
-  '@esbuild/win32-ia32@0.27.2':
-    optional: true
-
   '@esbuild/win32-x64@0.25.1':
-    optional: true
-
-  '@esbuild/win32-x64@0.27.2':
     optional: true
 
   '@eslint-community/eslint-utils@4.6.1(eslint@9.24.0(jiti@2.4.2))':
@@ -10190,7 +9837,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 22.14.1
+      '@types/node': 25.0.9
       '@types/yargs': 17.0.33
       chalk: 4.1.2
 
@@ -10255,31 +9902,31 @@ snapshots:
       - acorn
       - supports-color
 
-  '@mdx-js/react@3.1.0(@types/react@19.1.0)(react@18.3.1)':
+  '@mdx-js/react@3.1.0(@types/react@19.2.9)(react@18.3.1)':
     dependencies:
       '@types/mdx': 2.0.13
-      '@types/react': 19.1.0
+      '@types/react': 19.2.9
       react: 18.3.1
 
   '@mui/core-downloads-tracker@6.4.11': {}
 
-  '@mui/icons-material@6.4.11(@mui/material@6.4.11(@emotion/react@11.14.0(@types/react@19.1.0)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.0)(react@19.1.0))(@types/react@19.1.0)(react@19.1.0))(@types/react@19.1.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(@types/react@19.1.0)(react@19.1.0)':
+  '@mui/icons-material@6.4.11(@mui/material@6.4.11(@emotion/react@11.14.0(@types/react@19.2.9)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.2.9)(react@19.1.0))(@types/react@19.2.9)(react@19.1.0))(@types/react@19.2.9)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(@types/react@19.2.9)(react@19.1.0)':
     dependencies:
       '@babel/runtime': 7.27.0
-      '@mui/material': 6.4.11(@emotion/react@11.14.0(@types/react@19.1.0)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.0)(react@19.1.0))(@types/react@19.1.0)(react@19.1.0))(@types/react@19.1.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@mui/material': 6.4.11(@emotion/react@11.14.0(@types/react@19.2.9)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.2.9)(react@19.1.0))(@types/react@19.2.9)(react@19.1.0))(@types/react@19.2.9)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react: 19.1.0
     optionalDependencies:
-      '@types/react': 19.1.0
+      '@types/react': 19.2.9
 
-  '@mui/material@6.4.11(@emotion/react@11.14.0(@types/react@19.1.0)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.0)(react@19.1.0))(@types/react@19.1.0)(react@19.1.0))(@types/react@19.1.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@mui/material@6.4.11(@emotion/react@11.14.0(@types/react@19.2.9)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.2.9)(react@19.1.0))(@types/react@19.2.9)(react@19.1.0))(@types/react@19.2.9)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@babel/runtime': 7.27.0
       '@mui/core-downloads-tracker': 6.4.11
-      '@mui/system': 6.4.11(@emotion/react@11.14.0(@types/react@19.1.0)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.0)(react@19.1.0))(@types/react@19.1.0)(react@19.1.0))(@types/react@19.1.0)(react@19.1.0)
-      '@mui/types': 7.2.24(@types/react@19.1.0)
-      '@mui/utils': 6.4.9(@types/react@19.1.0)(react@19.1.0)
+      '@mui/system': 6.4.11(@emotion/react@11.14.0(@types/react@19.2.9)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.2.9)(react@19.1.0))(@types/react@19.2.9)(react@19.1.0))(@types/react@19.2.9)(react@19.1.0)
+      '@mui/types': 7.2.24(@types/react@19.2.9)
+      '@mui/utils': 6.4.9(@types/react@19.2.9)(react@19.1.0)
       '@popperjs/core': 2.11.8
-      '@types/react-transition-group': 4.4.12(@types/react@19.1.0)
+      '@types/react-transition-group': 4.4.12(@types/react@19.2.9)
       clsx: 2.1.1
       csstype: 3.1.3
       prop-types: 15.8.1
@@ -10288,22 +9935,22 @@ snapshots:
       react-is: 19.1.0
       react-transition-group: 4.4.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
     optionalDependencies:
-      '@emotion/react': 11.14.0(@types/react@19.1.0)(react@19.1.0)
-      '@emotion/styled': 11.14.0(@emotion/react@11.14.0(@types/react@19.1.0)(react@19.1.0))(@types/react@19.1.0)(react@19.1.0)
-      '@types/react': 19.1.0
+      '@emotion/react': 11.14.0(@types/react@19.2.9)(react@19.1.0)
+      '@emotion/styled': 11.14.0(@emotion/react@11.14.0(@types/react@19.2.9)(react@19.1.0))(@types/react@19.2.9)(react@19.1.0)
+      '@types/react': 19.2.9
 
-  '@mui/private-theming@6.4.9(@types/react@19.1.0)(react@19.1.0)':
+  '@mui/private-theming@6.4.9(@types/react@19.2.9)(react@19.1.0)':
     dependencies:
-      '@babel/runtime': 7.27.0
-      '@mui/utils': 6.4.9(@types/react@19.1.0)(react@19.1.0)
+      '@babel/runtime': 7.28.6
+      '@mui/utils': 6.4.9(@types/react@19.2.9)(react@19.1.0)
       prop-types: 15.8.1
       react: 19.1.0
     optionalDependencies:
-      '@types/react': 19.1.0
+      '@types/react': 19.2.9
 
-  '@mui/styled-engine@6.4.11(@emotion/react@11.14.0(@types/react@19.1.0)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.0)(react@19.1.0))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)':
+  '@mui/styled-engine@6.4.11(@emotion/react@11.14.0(@types/react@19.2.9)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.2.9)(react@19.1.0))(@types/react@19.2.9)(react@19.1.0))(react@19.1.0)':
     dependencies:
-      '@babel/runtime': 7.27.0
+      '@babel/runtime': 7.28.6
       '@emotion/cache': 11.14.0
       '@emotion/serialize': 1.3.3
       '@emotion/sheet': 1.4.0
@@ -10311,40 +9958,40 @@ snapshots:
       prop-types: 15.8.1
       react: 19.1.0
     optionalDependencies:
-      '@emotion/react': 11.14.0(@types/react@19.1.0)(react@19.1.0)
-      '@emotion/styled': 11.14.0(@emotion/react@11.14.0(@types/react@19.1.0)(react@19.1.0))(@types/react@19.1.0)(react@19.1.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.9)(react@19.1.0)
+      '@emotion/styled': 11.14.0(@emotion/react@11.14.0(@types/react@19.2.9)(react@19.1.0))(@types/react@19.2.9)(react@19.1.0)
 
-  '@mui/system@6.4.11(@emotion/react@11.14.0(@types/react@19.1.0)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.0)(react@19.1.0))(@types/react@19.1.0)(react@19.1.0))(@types/react@19.1.0)(react@19.1.0)':
+  '@mui/system@6.4.11(@emotion/react@11.14.0(@types/react@19.2.9)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.2.9)(react@19.1.0))(@types/react@19.2.9)(react@19.1.0))(@types/react@19.2.9)(react@19.1.0)':
     dependencies:
-      '@babel/runtime': 7.27.0
-      '@mui/private-theming': 6.4.9(@types/react@19.1.0)(react@19.1.0)
-      '@mui/styled-engine': 6.4.11(@emotion/react@11.14.0(@types/react@19.1.0)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.0)(react@19.1.0))(@types/react@19.1.0)(react@19.1.0))(react@19.1.0)
-      '@mui/types': 7.2.24(@types/react@19.1.0)
-      '@mui/utils': 6.4.9(@types/react@19.1.0)(react@19.1.0)
+      '@babel/runtime': 7.28.6
+      '@mui/private-theming': 6.4.9(@types/react@19.2.9)(react@19.1.0)
+      '@mui/styled-engine': 6.4.11(@emotion/react@11.14.0(@types/react@19.2.9)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.2.9)(react@19.1.0))(@types/react@19.2.9)(react@19.1.0))(react@19.1.0)
+      '@mui/types': 7.2.24(@types/react@19.2.9)
+      '@mui/utils': 6.4.9(@types/react@19.2.9)(react@19.1.0)
       clsx: 2.1.1
       csstype: 3.1.3
       prop-types: 15.8.1
       react: 19.1.0
     optionalDependencies:
-      '@emotion/react': 11.14.0(@types/react@19.1.0)(react@19.1.0)
-      '@emotion/styled': 11.14.0(@emotion/react@11.14.0(@types/react@19.1.0)(react@19.1.0))(@types/react@19.1.0)(react@19.1.0)
-      '@types/react': 19.1.0
+      '@emotion/react': 11.14.0(@types/react@19.2.9)(react@19.1.0)
+      '@emotion/styled': 11.14.0(@emotion/react@11.14.0(@types/react@19.2.9)(react@19.1.0))(@types/react@19.2.9)(react@19.1.0)
+      '@types/react': 19.2.9
 
-  '@mui/types@7.2.24(@types/react@19.1.0)':
+  '@mui/types@7.2.24(@types/react@19.2.9)':
     optionalDependencies:
-      '@types/react': 19.1.0
+      '@types/react': 19.2.9
 
-  '@mui/utils@6.4.9(@types/react@19.1.0)(react@19.1.0)':
+  '@mui/utils@6.4.9(@types/react@19.2.9)(react@19.1.0)':
     dependencies:
-      '@babel/runtime': 7.27.0
-      '@mui/types': 7.2.24(@types/react@19.1.0)
+      '@babel/runtime': 7.28.6
+      '@mui/types': 7.2.24(@types/react@19.2.9)
       '@types/prop-types': 15.7.14
       clsx: 2.1.1
       prop-types: 15.8.1
       react: 19.1.0
       react-is: 19.1.0
     optionalDependencies:
-      '@types/react': 19.1.0
+      '@types/react': 19.2.9
 
   '@napi-rs/wasm-runtime@0.2.9':
     dependencies:
@@ -10383,61 +10030,31 @@ snapshots:
 
   '@popperjs/core@2.11.8': {}
 
-  '@rollup/rollup-android-arm-eabi@4.37.0':
-    optional: true
-
   '@rollup/rollup-android-arm-eabi@4.56.0':
-    optional: true
-
-  '@rollup/rollup-android-arm64@4.37.0':
     optional: true
 
   '@rollup/rollup-android-arm64@4.56.0':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.37.0':
-    optional: true
-
   '@rollup/rollup-darwin-arm64@4.56.0':
-    optional: true
-
-  '@rollup/rollup-darwin-x64@4.37.0':
     optional: true
 
   '@rollup/rollup-darwin-x64@4.56.0':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.37.0':
-    optional: true
-
   '@rollup/rollup-freebsd-arm64@4.56.0':
-    optional: true
-
-  '@rollup/rollup-freebsd-x64@4.37.0':
     optional: true
 
   '@rollup/rollup-freebsd-x64@4.56.0':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.37.0':
-    optional: true
-
   '@rollup/rollup-linux-arm-gnueabihf@4.56.0':
-    optional: true
-
-  '@rollup/rollup-linux-arm-musleabihf@4.37.0':
     optional: true
 
   '@rollup/rollup-linux-arm-musleabihf@4.56.0':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.37.0':
-    optional: true
-
   '@rollup/rollup-linux-arm64-gnu@4.56.0':
-    optional: true
-
-  '@rollup/rollup-linux-arm64-musl@4.37.0':
     optional: true
 
   '@rollup/rollup-linux-arm64-musl@4.56.0':
@@ -10449,43 +10066,22 @@ snapshots:
   '@rollup/rollup-linux-loong64-musl@4.56.0':
     optional: true
 
-  '@rollup/rollup-linux-loongarch64-gnu@4.37.0':
-    optional: true
-
-  '@rollup/rollup-linux-powerpc64le-gnu@4.37.0':
-    optional: true
-
   '@rollup/rollup-linux-ppc64-gnu@4.56.0':
     optional: true
 
   '@rollup/rollup-linux-ppc64-musl@4.56.0':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.37.0':
-    optional: true
-
   '@rollup/rollup-linux-riscv64-gnu@4.56.0':
-    optional: true
-
-  '@rollup/rollup-linux-riscv64-musl@4.37.0':
     optional: true
 
   '@rollup/rollup-linux-riscv64-musl@4.56.0':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.37.0':
-    optional: true
-
   '@rollup/rollup-linux-s390x-gnu@4.56.0':
     optional: true
 
-  '@rollup/rollup-linux-x64-gnu@4.37.0':
-    optional: true
-
   '@rollup/rollup-linux-x64-gnu@4.56.0':
-    optional: true
-
-  '@rollup/rollup-linux-x64-musl@4.37.0':
     optional: true
 
   '@rollup/rollup-linux-x64-musl@4.56.0':
@@ -10497,22 +10093,13 @@ snapshots:
   '@rollup/rollup-openharmony-arm64@4.56.0':
     optional: true
 
-  '@rollup/rollup-win32-arm64-msvc@4.37.0':
-    optional: true
-
   '@rollup/rollup-win32-arm64-msvc@4.56.0':
-    optional: true
-
-  '@rollup/rollup-win32-ia32-msvc@4.37.0':
     optional: true
 
   '@rollup/rollup-win32-ia32-msvc@4.56.0':
     optional: true
 
   '@rollup/rollup-win32-x64-gnu@4.56.0':
-    optional: true
-
-  '@rollup/rollup-win32-x64-msvc@4.37.0':
     optional: true
 
   '@rollup/rollup-win32-x64-msvc@4.56.0':
@@ -10699,11 +10286,11 @@ snapshots:
   '@types/body-parser@1.19.5':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 22.14.1
+      '@types/node': 25.0.9
 
   '@types/bonjour@3.5.13':
     dependencies:
-      '@types/node': 22.14.1
+      '@types/node': 25.0.9
 
   '@types/chai@5.2.3':
     dependencies:
@@ -10713,15 +10300,15 @@ snapshots:
   '@types/connect-history-api-fallback@1.5.4':
     dependencies:
       '@types/express-serve-static-core': 5.0.6
-      '@types/node': 22.14.1
+      '@types/node': 25.0.9
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 22.14.1
+      '@types/node': 25.0.9
 
   '@types/conventional-commits-parser@5.0.1':
     dependencies:
-      '@types/node': 22.14.1
+      '@types/node': 25.0.9
 
   '@types/cookie@0.6.0': {}
 
@@ -10738,14 +10325,12 @@ snapshots:
 
   '@types/eslint@9.6.1':
     dependencies:
-      '@types/estree': 1.0.7
+      '@types/estree': 1.0.8
       '@types/json-schema': 7.0.15
 
   '@types/estree-jsx@1.0.5':
     dependencies:
       '@types/estree': 1.0.7
-
-  '@types/estree@1.0.6': {}
 
   '@types/estree@1.0.7': {}
 
@@ -10753,30 +10338,30 @@ snapshots:
 
   '@types/express-serve-static-core@4.19.6':
     dependencies:
-      '@types/node': 22.14.1
+      '@types/node': 25.0.9
       '@types/qs': 6.9.18
       '@types/range-parser': 1.2.7
       '@types/send': 0.17.4
 
   '@types/express-serve-static-core@5.0.6':
     dependencies:
-      '@types/node': 22.14.1
+      '@types/node': 25.0.9
       '@types/qs': 6.9.18
       '@types/range-parser': 1.2.7
       '@types/send': 0.17.4
 
-  '@types/express@4.17.21':
+  '@types/express@4.17.25':
     dependencies:
       '@types/body-parser': 1.19.5
       '@types/express-serve-static-core': 4.19.6
       '@types/qs': 6.9.18
-      '@types/serve-static': 1.15.7
+      '@types/serve-static': 1.15.10
 
-  '@types/express@5.0.3':
+  '@types/express@5.0.6':
     dependencies:
       '@types/body-parser': 1.19.5
       '@types/express-serve-static-core': 5.0.6
-      '@types/serve-static': 1.15.7
+      '@types/serve-static': 2.2.0
 
   '@types/gtag.js@0.0.12': {}
 
@@ -10790,11 +10375,11 @@ snapshots:
 
   '@types/http-cache-semantics@4.0.4': {}
 
-  '@types/http-errors@2.0.4': {}
+  '@types/http-errors@2.0.5': {}
 
   '@types/http-proxy@1.17.16':
     dependencies:
-      '@types/node': 22.14.1
+      '@types/node': 25.0.9
 
   '@types/istanbul-lib-coverage@2.0.6': {}
 
@@ -10822,13 +10407,17 @@ snapshots:
 
   '@types/node-forge@1.3.11':
     dependencies:
-      '@types/node': 22.14.1
+      '@types/node': 25.0.9
 
   '@types/node@17.0.45': {}
 
   '@types/node@22.14.1':
     dependencies:
       undici-types: 6.21.0
+
+  '@types/node@25.0.9':
+    dependencies:
+      undici-types: 7.16.0
 
   '@types/parse-json@4.0.2': {}
 
@@ -10861,16 +10450,16 @@ snapshots:
       '@types/history': 4.7.11
       '@types/react': 18.3.20
 
-  '@types/react-transition-group@4.4.12(@types/react@19.1.0)':
+  '@types/react-transition-group@4.4.12(@types/react@19.2.9)':
     dependencies:
-      '@types/react': 19.1.0
+      '@types/react': 19.2.9
 
   '@types/react@18.3.20':
     dependencies:
       '@types/prop-types': 15.7.14
       csstype: 3.1.3
 
-  '@types/react@19.1.0':
+  '@types/react@19.2.9':
     dependencies:
       csstype: 3.2.3
 
@@ -10878,26 +10467,31 @@ snapshots:
 
   '@types/sax@1.2.7':
     dependencies:
-      '@types/node': 22.14.1
+      '@types/node': 25.0.9
 
   '@types/send@0.17.4':
     dependencies:
       '@types/mime': 1.3.5
-      '@types/node': 22.14.1
+      '@types/node': 25.0.9
 
   '@types/serve-index@1.9.4':
     dependencies:
-      '@types/express': 5.0.3
+      '@types/express': 4.17.25
 
-  '@types/serve-static@1.15.7':
+  '@types/serve-static@1.15.10':
     dependencies:
-      '@types/http-errors': 2.0.4
-      '@types/node': 22.14.1
+      '@types/http-errors': 2.0.5
+      '@types/node': 25.0.9
       '@types/send': 0.17.4
+
+  '@types/serve-static@2.2.0':
+    dependencies:
+      '@types/http-errors': 2.0.5
+      '@types/node': 25.0.9
 
   '@types/sockjs@0.3.36':
     dependencies:
-      '@types/node': 22.14.1
+      '@types/node': 25.0.9
 
   '@types/trusted-types@2.0.7':
     optional: true
@@ -10908,7 +10502,7 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 22.14.1
+      '@types/node': 25.0.9
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -10954,7 +10548,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 8.30.1(typescript@5.8.3)
       '@typescript-eslint/utils': 8.30.1(eslint@9.24.0(jiti@2.4.2))(typescript@5.8.3)
-      debug: 4.4.0
+      debug: 4.4.3
       eslint: 9.24.0(jiti@2.4.2)
       ts-api-utils: 2.1.0(typescript@5.8.3)
       typescript: 5.8.3
@@ -11045,14 +10639,14 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.5.0':
     optional: true
 
-  '@vitejs/plugin-react@4.4.0(vite@6.3.2(@types/node@22.14.1)(jiti@2.4.2)(terser@5.39.0))':
+  '@vitejs/plugin-react@4.4.0(vite@6.3.2(@types/node@25.0.9)(jiti@2.4.2)(terser@5.39.0))':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/plugin-transform-react-jsx-self': 7.25.9(@babel/core@7.26.10)
       '@babel/plugin-transform-react-jsx-source': 7.25.9(@babel/core@7.26.10)
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 6.3.2(@types/node@22.14.1)(jiti@2.4.2)(terser@5.39.0)
+      vite: 6.3.2(@types/node@25.0.9)(jiti@2.4.2)(terser@5.39.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -11079,13 +10673,21 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@22.14.1)(jiti@2.4.2)(terser@5.39.0))':
+  '@vitest/mocker@4.0.18(vite@6.3.2(@types/node@22.14.1)(jiti@2.4.2)(terser@5.39.0))':
     dependencies:
       '@vitest/spy': 4.0.18
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@22.14.1)(jiti@2.4.2)(terser@5.39.0)
+      vite: 6.3.2(@types/node@22.14.1)(jiti@2.4.2)(terser@5.39.0)
+
+  '@vitest/mocker@4.0.18(vite@6.3.2(@types/node@25.0.9)(jiti@2.4.2)(terser@5.39.0))':
+    dependencies:
+      '@vitest/spy': 4.0.18
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 6.3.2(@types/node@25.0.9)(jiti@2.4.2)(terser@5.39.0)
 
   '@vitest/pretty-format@4.0.18':
     dependencies:
@@ -11407,6 +11009,16 @@ snapshots:
       postcss: 8.5.3
       postcss-value-parser: 4.2.0
 
+  autoprefixer@10.4.21(postcss@8.5.6):
+    dependencies:
+      browserslist: 4.24.4
+      caniuse-lite: 1.0.30001714
+      fraction.js: 4.3.7
+      normalize-range: 0.1.2
+      picocolors: 1.1.1
+      postcss: 8.5.6
+      postcss-value-parser: 4.2.0
+
   autosuggest-highlight@3.3.4:
     dependencies:
       remove-accents: 0.4.4
@@ -11436,7 +11048,7 @@ snapshots:
 
   babel-plugin-macros@3.1.0:
     dependencies:
-      '@babel/runtime': 7.27.0
+      '@babel/runtime': 7.28.6
       cosmiconfig: 7.1.0
       resolve: 1.22.10
 
@@ -11474,33 +11086,33 @@ snapshots:
 
   binary-extensions@2.3.0: {}
 
-  body-parser@1.20.3:
+  body-parser@1.20.4:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
       debug: 2.6.9
       depd: 2.0.0
       destroy: 1.2.0
-      http-errors: 2.0.0
+      http-errors: 2.0.1
       iconv-lite: 0.4.24
       on-finished: 2.4.1
-      qs: 6.13.0
-      raw-body: 2.5.2
+      qs: 6.14.1
+      raw-body: 2.5.3
       type-is: 1.6.18
       unpipe: 1.0.0
     transitivePeerDependencies:
       - supports-color
 
-  body-parser@2.2.0:
+  body-parser@2.2.2:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 4.4.0
+      debug: 4.4.3
       http-errors: 2.0.0
-      iconv-lite: 0.6.3
+      iconv-lite: 0.7.2
       on-finished: 2.4.1
-      qs: 6.14.0
-      raw-body: 3.0.0
+      qs: 6.14.1
+      raw-body: 3.0.2
       type-is: 2.0.1
     transitivePeerDependencies:
       - supports-color
@@ -11886,6 +11498,10 @@ snapshots:
     dependencies:
       postcss: 8.5.3
 
+  css-declaration-sorter@7.2.0(postcss@8.5.6):
+    dependencies:
+      postcss: 8.5.6
+
   css-has-pseudo@7.0.2(postcss@8.5.3):
     dependencies:
       '@csstools/selector-specificity': 5.0.0(postcss-selector-parser@7.1.0)
@@ -11895,12 +11511,12 @@ snapshots:
 
   css-loader@6.11.0(webpack@5.99.6):
     dependencies:
-      icss-utils: 5.1.0(postcss@8.5.3)
-      postcss: 8.5.3
-      postcss-modules-extract-imports: 3.1.0(postcss@8.5.3)
-      postcss-modules-local-by-default: 4.2.0(postcss@8.5.3)
-      postcss-modules-scope: 3.2.1(postcss@8.5.3)
-      postcss-modules-values: 4.0.0(postcss@8.5.3)
+      icss-utils: 5.1.0(postcss@8.5.6)
+      postcss: 8.5.6
+      postcss-modules-extract-imports: 3.1.0(postcss@8.5.6)
+      postcss-modules-local-by-default: 4.2.0(postcss@8.5.6)
+      postcss-modules-scope: 3.2.1(postcss@8.5.6)
+      postcss-modules-values: 4.0.0(postcss@8.5.6)
       postcss-value-parser: 4.2.0
       semver: 7.7.1
     optionalDependencies:
@@ -11911,9 +11527,9 @@ snapshots:
   css-minimizer-webpack-plugin@5.0.1(clean-css@5.3.3)(webpack@5.99.6):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
-      cssnano: 6.1.2(postcss@8.5.3)
+      cssnano: 6.1.2(postcss@8.5.6)
       jest-worker: 29.7.0
-      postcss: 8.5.3
+      postcss: 8.5.6
       schema-utils: 4.3.0
       serialize-javascript: 6.0.2
       webpack: 5.99.6
@@ -11956,16 +11572,16 @@ snapshots:
 
   cssesc@3.0.0: {}
 
-  cssnano-preset-advanced@6.1.2(postcss@8.5.3):
+  cssnano-preset-advanced@6.1.2(postcss@8.5.6):
     dependencies:
-      autoprefixer: 10.4.21(postcss@8.5.3)
+      autoprefixer: 10.4.21(postcss@8.5.6)
       browserslist: 4.24.4
-      cssnano-preset-default: 6.1.2(postcss@8.5.3)
-      postcss: 8.5.3
-      postcss-discard-unused: 6.0.5(postcss@8.5.3)
-      postcss-merge-idents: 6.0.3(postcss@8.5.3)
-      postcss-reduce-idents: 6.0.3(postcss@8.5.3)
-      postcss-zindex: 6.0.2(postcss@8.5.3)
+      cssnano-preset-default: 6.1.2(postcss@8.5.6)
+      postcss: 8.5.6
+      postcss-discard-unused: 6.0.5(postcss@8.5.6)
+      postcss-merge-idents: 6.0.3(postcss@8.5.6)
+      postcss-reduce-idents: 6.0.3(postcss@8.5.6)
+      postcss-zindex: 6.0.2(postcss@8.5.6)
 
   cssnano-preset-default@6.1.2(postcss@8.5.3):
     dependencies:
@@ -12001,15 +11617,59 @@ snapshots:
       postcss-svgo: 6.0.3(postcss@8.5.3)
       postcss-unique-selectors: 6.0.4(postcss@8.5.3)
 
+  cssnano-preset-default@6.1.2(postcss@8.5.6):
+    dependencies:
+      browserslist: 4.24.4
+      css-declaration-sorter: 7.2.0(postcss@8.5.6)
+      cssnano-utils: 4.0.2(postcss@8.5.6)
+      postcss: 8.5.6
+      postcss-calc: 9.0.1(postcss@8.5.6)
+      postcss-colormin: 6.1.0(postcss@8.5.6)
+      postcss-convert-values: 6.1.0(postcss@8.5.6)
+      postcss-discard-comments: 6.0.2(postcss@8.5.6)
+      postcss-discard-duplicates: 6.0.3(postcss@8.5.6)
+      postcss-discard-empty: 6.0.3(postcss@8.5.6)
+      postcss-discard-overridden: 6.0.2(postcss@8.5.6)
+      postcss-merge-longhand: 6.0.5(postcss@8.5.6)
+      postcss-merge-rules: 6.1.1(postcss@8.5.6)
+      postcss-minify-font-values: 6.1.0(postcss@8.5.6)
+      postcss-minify-gradients: 6.0.3(postcss@8.5.6)
+      postcss-minify-params: 6.1.0(postcss@8.5.6)
+      postcss-minify-selectors: 6.0.4(postcss@8.5.6)
+      postcss-normalize-charset: 6.0.2(postcss@8.5.6)
+      postcss-normalize-display-values: 6.0.2(postcss@8.5.6)
+      postcss-normalize-positions: 6.0.2(postcss@8.5.6)
+      postcss-normalize-repeat-style: 6.0.2(postcss@8.5.6)
+      postcss-normalize-string: 6.0.2(postcss@8.5.6)
+      postcss-normalize-timing-functions: 6.0.2(postcss@8.5.6)
+      postcss-normalize-unicode: 6.1.0(postcss@8.5.6)
+      postcss-normalize-url: 6.0.2(postcss@8.5.6)
+      postcss-normalize-whitespace: 6.0.2(postcss@8.5.6)
+      postcss-ordered-values: 6.0.2(postcss@8.5.6)
+      postcss-reduce-initial: 6.1.0(postcss@8.5.6)
+      postcss-reduce-transforms: 6.0.2(postcss@8.5.6)
+      postcss-svgo: 6.0.3(postcss@8.5.6)
+      postcss-unique-selectors: 6.0.4(postcss@8.5.6)
+
   cssnano-utils@4.0.2(postcss@8.5.3):
     dependencies:
       postcss: 8.5.3
+
+  cssnano-utils@4.0.2(postcss@8.5.6):
+    dependencies:
+      postcss: 8.5.6
 
   cssnano@6.1.2(postcss@8.5.3):
     dependencies:
       cssnano-preset-default: 6.1.2(postcss@8.5.3)
       lilconfig: 3.1.3
       postcss: 8.5.3
+
+  cssnano@6.1.2(postcss@8.5.6):
+    dependencies:
+      cssnano-preset-default: 6.1.2(postcss@8.5.6)
+      lilconfig: 3.1.3
+      postcss: 8.5.6
 
   csso@5.0.5:
     dependencies:
@@ -12066,6 +11726,10 @@ snapshots:
       ms: 2.1.3
 
   debug@4.4.0:
+    dependencies:
+      ms: 2.1.3
+
+  debug@4.4.3:
     dependencies:
       ms: 2.1.3
 
@@ -12166,7 +11830,7 @@ snapshots:
 
   dom-helpers@5.2.1:
     dependencies:
-      '@babel/runtime': 7.27.0
+      '@babel/runtime': 7.28.6
       csstype: 3.1.3
 
   dom-serializer@1.4.1:
@@ -12412,35 +12076,6 @@ snapshots:
       '@esbuild/win32-ia32': 0.25.1
       '@esbuild/win32-x64': 0.25.1
 
-  esbuild@0.27.2:
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.27.2
-      '@esbuild/android-arm': 0.27.2
-      '@esbuild/android-arm64': 0.27.2
-      '@esbuild/android-x64': 0.27.2
-      '@esbuild/darwin-arm64': 0.27.2
-      '@esbuild/darwin-x64': 0.27.2
-      '@esbuild/freebsd-arm64': 0.27.2
-      '@esbuild/freebsd-x64': 0.27.2
-      '@esbuild/linux-arm': 0.27.2
-      '@esbuild/linux-arm64': 0.27.2
-      '@esbuild/linux-ia32': 0.27.2
-      '@esbuild/linux-loong64': 0.27.2
-      '@esbuild/linux-mips64el': 0.27.2
-      '@esbuild/linux-ppc64': 0.27.2
-      '@esbuild/linux-riscv64': 0.27.2
-      '@esbuild/linux-s390x': 0.27.2
-      '@esbuild/linux-x64': 0.27.2
-      '@esbuild/netbsd-arm64': 0.27.2
-      '@esbuild/netbsd-x64': 0.27.2
-      '@esbuild/openbsd-arm64': 0.27.2
-      '@esbuild/openbsd-x64': 0.27.2
-      '@esbuild/openharmony-arm64': 0.27.2
-      '@esbuild/sunos-x64': 0.27.2
-      '@esbuild/win32-arm64': 0.27.2
-      '@esbuild/win32-ia32': 0.27.2
-      '@esbuild/win32-x64': 0.27.2
-
   escalade@3.2.0: {}
 
   escape-goat@4.0.0: {}
@@ -12637,7 +12272,7 @@ snapshots:
 
   estree-util-attach-comments@3.0.0:
     dependencies:
-      '@types/estree': 1.0.7
+      '@types/estree': 1.0.8
 
   estree-util-build-jsx@3.0.1:
     dependencies:
@@ -12680,7 +12315,7 @@ snapshots:
 
   eval@0.1.8:
     dependencies:
-      '@types/node': 22.14.1
+      '@types/node': 25.0.9
       require-like: 0.1.2
 
   eventemitter3@4.0.7: {}
@@ -12703,11 +12338,11 @@ snapshots:
 
   expect-type@1.3.0: {}
 
-  express@4.21.2:
+  express@4.22.1:
     dependencies:
       accepts: 1.3.8
       array-flatten: 1.1.1
-      body-parser: 1.20.3
+      body-parser: 1.20.4
       content-disposition: 0.5.4
       content-type: 1.0.5
       cookie: 0.7.1
@@ -12719,14 +12354,14 @@ snapshots:
       etag: 1.8.1
       finalhandler: 1.3.1
       fresh: 0.5.2
-      http-errors: 2.0.0
+      http-errors: 2.0.1
       merge-descriptors: 1.0.3
       methods: 1.1.2
       on-finished: 2.4.1
       parseurl: 1.3.3
       path-to-regexp: 0.1.12
       proxy-addr: 2.0.7
-      qs: 6.13.0
+      qs: 6.14.1
       range-parser: 1.2.1
       safe-buffer: 5.2.1
       send: 0.19.0
@@ -12739,15 +12374,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  express@5.1.0:
+  express@5.2.1:
     dependencies:
       accepts: 2.0.0
-      body-parser: 2.2.0
+      body-parser: 2.2.2
       content-disposition: 1.0.0
       content-type: 1.0.5
       cookie: 0.7.1
       cookie-signature: 1.2.2
       debug: 4.4.0
+      depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -13187,7 +12823,7 @@ snapshots:
 
   hast-util-to-estree@3.1.3:
     dependencies:
-      '@types/estree': 1.0.7
+      '@types/estree': 1.0.8
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.4
       comma-separated-tokens: 2.0.3
@@ -13252,7 +12888,7 @@ snapshots:
 
   history@4.10.1:
     dependencies:
-      '@babel/runtime': 7.27.0
+      '@babel/runtime': 7.28.6
       loose-envify: 1.4.0
       resolve-pathname: 3.0.0
       tiny-invariant: 1.3.3
@@ -13345,6 +12981,14 @@ snapshots:
       statuses: 2.0.1
       toidentifier: 1.0.1
 
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+
   http-parser-js@0.5.10: {}
 
   http-proxy-agent@7.0.2:
@@ -13354,7 +12998,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  http-proxy-middleware@2.0.9(@types/express@4.17.21):
+  http-proxy-middleware@2.0.9(@types/express@4.17.25):
     dependencies:
       '@types/http-proxy': 1.17.16
       http-proxy: 1.18.1
@@ -13362,7 +13006,7 @@ snapshots:
       is-plain-obj: 3.0.0
       micromatch: 4.0.8
     optionalDependencies:
-      '@types/express': 4.17.21
+      '@types/express': 4.17.25
     transitivePeerDependencies:
       - debug
 
@@ -13398,9 +13042,13 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
-  icss-utils@5.1.0(postcss@8.5.3):
+  iconv-lite@0.7.2:
     dependencies:
-      postcss: 8.5.3
+      safer-buffer: 2.1.2
+
+  icss-utils@5.1.0(postcss@8.5.6):
+    dependencies:
+      postcss: 8.5.6
 
   ignore@5.3.2: {}
 
@@ -13694,7 +13342,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 22.14.1
+      '@types/node': 25.0.9
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -13702,13 +13350,13 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 22.14.1
+      '@types/node': 25.0.9
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 22.14.1
+      '@types/node': 25.0.9
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
@@ -14227,7 +13875,7 @@ snapshots:
 
   micromark-extension-mdx-expression@3.0.1:
     dependencies:
-      '@types/estree': 1.0.7
+      '@types/estree': 1.0.8
       devlop: 1.1.0
       micromark-factory-mdx-expression: 2.0.3
       micromark-factory-space: 2.0.1
@@ -14238,7 +13886,7 @@ snapshots:
 
   micromark-extension-mdx-jsx@3.0.2:
     dependencies:
-      '@types/estree': 1.0.7
+      '@types/estree': 1.0.8
       devlop: 1.1.0
       estree-util-is-identifier-name: 3.0.0
       micromark-factory-mdx-expression: 2.0.3
@@ -14255,7 +13903,7 @@ snapshots:
 
   micromark-extension-mdxjs-esm@3.0.0:
     dependencies:
-      '@types/estree': 1.0.7
+      '@types/estree': 1.0.8
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
       micromark-util-character: 2.1.1
@@ -14291,7 +13939,7 @@ snapshots:
 
   micromark-factory-mdx-expression@2.0.3:
     dependencies:
-      '@types/estree': 1.0.7
+      '@types/estree': 1.0.8
       devlop: 1.1.0
       micromark-factory-space: 2.0.1
       micromark-util-character: 2.1.1
@@ -14365,7 +14013,7 @@ snapshots:
 
   micromark-util-events-to-acorn@2.0.3:
     dependencies:
-      '@types/estree': 1.0.7
+      '@types/estree': 1.0.8
       '@types/unist': 3.0.3
       devlop: 1.1.0
       estree-util-visit: 2.0.0
@@ -14407,7 +14055,7 @@ snapshots:
   micromark@4.0.2:
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.4.0
+      debug: 4.4.3
       decode-named-character-reference: 1.1.0
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
@@ -14785,6 +14433,12 @@ snapshots:
       postcss-selector-parser: 6.1.2
       postcss-value-parser: 4.2.0
 
+  postcss-calc@9.0.1(postcss@8.5.6):
+    dependencies:
+      postcss: 8.5.6
+      postcss-selector-parser: 6.1.2
+      postcss-value-parser: 4.2.0
+
   postcss-clamp@4.1.0(postcss@8.5.3):
     dependencies:
       postcss: 8.5.3
@@ -14819,10 +14473,24 @@ snapshots:
       postcss: 8.5.3
       postcss-value-parser: 4.2.0
 
+  postcss-colormin@6.1.0(postcss@8.5.6):
+    dependencies:
+      browserslist: 4.24.4
+      caniuse-api: 3.0.0
+      colord: 2.9.3
+      postcss: 8.5.6
+      postcss-value-parser: 4.2.0
+
   postcss-convert-values@6.1.0(postcss@8.5.3):
     dependencies:
       browserslist: 4.24.4
       postcss: 8.5.3
+      postcss-value-parser: 4.2.0
+
+  postcss-convert-values@6.1.0(postcss@8.5.6):
+    dependencies:
+      browserslist: 4.24.4
+      postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
   postcss-custom-media@11.0.5(postcss@8.5.3):
@@ -14859,21 +14527,37 @@ snapshots:
     dependencies:
       postcss: 8.5.3
 
+  postcss-discard-comments@6.0.2(postcss@8.5.6):
+    dependencies:
+      postcss: 8.5.6
+
   postcss-discard-duplicates@6.0.3(postcss@8.5.3):
     dependencies:
       postcss: 8.5.3
+
+  postcss-discard-duplicates@6.0.3(postcss@8.5.6):
+    dependencies:
+      postcss: 8.5.6
 
   postcss-discard-empty@6.0.3(postcss@8.5.3):
     dependencies:
       postcss: 8.5.3
 
+  postcss-discard-empty@6.0.3(postcss@8.5.6):
+    dependencies:
+      postcss: 8.5.6
+
   postcss-discard-overridden@6.0.2(postcss@8.5.3):
     dependencies:
       postcss: 8.5.3
 
-  postcss-discard-unused@6.0.5(postcss@8.5.3):
+  postcss-discard-overridden@6.0.2(postcss@8.5.6):
     dependencies:
-      postcss: 8.5.3
+      postcss: 8.5.6
+
+  postcss-discard-unused@6.0.5(postcss@8.5.6):
+    dependencies:
+      postcss: 8.5.6
       postcss-selector-parser: 6.1.2
 
   postcss-double-position-gradients@6.0.0(postcss@8.5.3):
@@ -14931,10 +14615,10 @@ snapshots:
       postcss: 8.5.3
       postcss-value-parser: 4.2.0
 
-  postcss-merge-idents@6.0.3(postcss@8.5.3):
+  postcss-merge-idents@6.0.3(postcss@8.5.6):
     dependencies:
-      cssnano-utils: 4.0.2(postcss@8.5.3)
-      postcss: 8.5.3
+      cssnano-utils: 4.0.2(postcss@8.5.6)
+      postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
   postcss-merge-longhand@6.0.5(postcss@8.5.3):
@@ -14942,6 +14626,12 @@ snapshots:
       postcss: 8.5.3
       postcss-value-parser: 4.2.0
       stylehacks: 6.1.1(postcss@8.5.3)
+
+  postcss-merge-longhand@6.0.5(postcss@8.5.6):
+    dependencies:
+      postcss: 8.5.6
+      postcss-value-parser: 4.2.0
+      stylehacks: 6.1.1(postcss@8.5.6)
 
   postcss-merge-rules@6.1.1(postcss@8.5.3):
     dependencies:
@@ -14951,9 +14641,22 @@ snapshots:
       postcss: 8.5.3
       postcss-selector-parser: 6.1.2
 
+  postcss-merge-rules@6.1.1(postcss@8.5.6):
+    dependencies:
+      browserslist: 4.24.4
+      caniuse-api: 3.0.0
+      cssnano-utils: 4.0.2(postcss@8.5.6)
+      postcss: 8.5.6
+      postcss-selector-parser: 6.1.2
+
   postcss-minify-font-values@6.1.0(postcss@8.5.3):
     dependencies:
       postcss: 8.5.3
+      postcss-value-parser: 4.2.0
+
+  postcss-minify-font-values@6.1.0(postcss@8.5.6):
+    dependencies:
+      postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
   postcss-minify-gradients@6.0.3(postcss@8.5.3):
@@ -14963,6 +14666,13 @@ snapshots:
       postcss: 8.5.3
       postcss-value-parser: 4.2.0
 
+  postcss-minify-gradients@6.0.3(postcss@8.5.6):
+    dependencies:
+      colord: 2.9.3
+      cssnano-utils: 4.0.2(postcss@8.5.6)
+      postcss: 8.5.6
+      postcss-value-parser: 4.2.0
+
   postcss-minify-params@6.1.0(postcss@8.5.3):
     dependencies:
       browserslist: 4.24.4
@@ -14970,31 +14680,43 @@ snapshots:
       postcss: 8.5.3
       postcss-value-parser: 4.2.0
 
+  postcss-minify-params@6.1.0(postcss@8.5.6):
+    dependencies:
+      browserslist: 4.24.4
+      cssnano-utils: 4.0.2(postcss@8.5.6)
+      postcss: 8.5.6
+      postcss-value-parser: 4.2.0
+
   postcss-minify-selectors@6.0.4(postcss@8.5.3):
     dependencies:
       postcss: 8.5.3
       postcss-selector-parser: 6.1.2
 
-  postcss-modules-extract-imports@3.1.0(postcss@8.5.3):
+  postcss-minify-selectors@6.0.4(postcss@8.5.6):
     dependencies:
-      postcss: 8.5.3
+      postcss: 8.5.6
+      postcss-selector-parser: 6.1.2
 
-  postcss-modules-local-by-default@4.2.0(postcss@8.5.3):
+  postcss-modules-extract-imports@3.1.0(postcss@8.5.6):
     dependencies:
-      icss-utils: 5.1.0(postcss@8.5.3)
-      postcss: 8.5.3
+      postcss: 8.5.6
+
+  postcss-modules-local-by-default@4.2.0(postcss@8.5.6):
+    dependencies:
+      icss-utils: 5.1.0(postcss@8.5.6)
+      postcss: 8.5.6
       postcss-selector-parser: 7.1.0
       postcss-value-parser: 4.2.0
 
-  postcss-modules-scope@3.2.1(postcss@8.5.3):
+  postcss-modules-scope@3.2.1(postcss@8.5.6):
     dependencies:
-      postcss: 8.5.3
+      postcss: 8.5.6
       postcss-selector-parser: 7.1.0
 
-  postcss-modules-values@4.0.0(postcss@8.5.3):
+  postcss-modules-values@4.0.0(postcss@8.5.6):
     dependencies:
-      icss-utils: 5.1.0(postcss@8.5.3)
-      postcss: 8.5.3
+      icss-utils: 5.1.0(postcss@8.5.6)
+      postcss: 8.5.6
 
   postcss-nesting@13.0.1(postcss@8.5.3):
     dependencies:
@@ -15007,9 +14729,18 @@ snapshots:
     dependencies:
       postcss: 8.5.3
 
+  postcss-normalize-charset@6.0.2(postcss@8.5.6):
+    dependencies:
+      postcss: 8.5.6
+
   postcss-normalize-display-values@6.0.2(postcss@8.5.3):
     dependencies:
       postcss: 8.5.3
+      postcss-value-parser: 4.2.0
+
+  postcss-normalize-display-values@6.0.2(postcss@8.5.6):
+    dependencies:
+      postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
   postcss-normalize-positions@6.0.2(postcss@8.5.3):
@@ -15017,9 +14748,19 @@ snapshots:
       postcss: 8.5.3
       postcss-value-parser: 4.2.0
 
+  postcss-normalize-positions@6.0.2(postcss@8.5.6):
+    dependencies:
+      postcss: 8.5.6
+      postcss-value-parser: 4.2.0
+
   postcss-normalize-repeat-style@6.0.2(postcss@8.5.3):
     dependencies:
       postcss: 8.5.3
+      postcss-value-parser: 4.2.0
+
+  postcss-normalize-repeat-style@6.0.2(postcss@8.5.6):
+    dependencies:
+      postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
   postcss-normalize-string@6.0.2(postcss@8.5.3):
@@ -15027,9 +14768,19 @@ snapshots:
       postcss: 8.5.3
       postcss-value-parser: 4.2.0
 
+  postcss-normalize-string@6.0.2(postcss@8.5.6):
+    dependencies:
+      postcss: 8.5.6
+      postcss-value-parser: 4.2.0
+
   postcss-normalize-timing-functions@6.0.2(postcss@8.5.3):
     dependencies:
       postcss: 8.5.3
+      postcss-value-parser: 4.2.0
+
+  postcss-normalize-timing-functions@6.0.2(postcss@8.5.6):
+    dependencies:
+      postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
   postcss-normalize-unicode@6.1.0(postcss@8.5.3):
@@ -15038,14 +14789,30 @@ snapshots:
       postcss: 8.5.3
       postcss-value-parser: 4.2.0
 
+  postcss-normalize-unicode@6.1.0(postcss@8.5.6):
+    dependencies:
+      browserslist: 4.24.4
+      postcss: 8.5.6
+      postcss-value-parser: 4.2.0
+
   postcss-normalize-url@6.0.2(postcss@8.5.3):
     dependencies:
       postcss: 8.5.3
       postcss-value-parser: 4.2.0
 
+  postcss-normalize-url@6.0.2(postcss@8.5.6):
+    dependencies:
+      postcss: 8.5.6
+      postcss-value-parser: 4.2.0
+
   postcss-normalize-whitespace@6.0.2(postcss@8.5.3):
     dependencies:
       postcss: 8.5.3
+      postcss-value-parser: 4.2.0
+
+  postcss-normalize-whitespace@6.0.2(postcss@8.5.6):
+    dependencies:
+      postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
   postcss-opacity-percentage@3.0.0(postcss@8.5.3):
@@ -15056,6 +14823,12 @@ snapshots:
     dependencies:
       cssnano-utils: 4.0.2(postcss@8.5.3)
       postcss: 8.5.3
+      postcss-value-parser: 4.2.0
+
+  postcss-ordered-values@6.0.2(postcss@8.5.6):
+    dependencies:
+      cssnano-utils: 4.0.2(postcss@8.5.6)
+      postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
   postcss-overflow-shorthand@6.0.0(postcss@8.5.3):
@@ -15144,9 +14917,9 @@ snapshots:
       postcss: 8.5.3
       postcss-selector-parser: 7.1.0
 
-  postcss-reduce-idents@6.0.3(postcss@8.5.3):
+  postcss-reduce-idents@6.0.3(postcss@8.5.6):
     dependencies:
-      postcss: 8.5.3
+      postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
   postcss-reduce-initial@6.1.0(postcss@8.5.3):
@@ -15155,9 +14928,20 @@ snapshots:
       caniuse-api: 3.0.0
       postcss: 8.5.3
 
+  postcss-reduce-initial@6.1.0(postcss@8.5.6):
+    dependencies:
+      browserslist: 4.24.4
+      caniuse-api: 3.0.0
+      postcss: 8.5.6
+
   postcss-reduce-transforms@6.0.2(postcss@8.5.3):
     dependencies:
       postcss: 8.5.3
+      postcss-value-parser: 4.2.0
+
+  postcss-reduce-transforms@6.0.2(postcss@8.5.6):
+    dependencies:
+      postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
   postcss-replace-overflow-wrap@4.0.0(postcss@8.5.3):
@@ -15179,9 +14963,9 @@ snapshots:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
 
-  postcss-sort-media-queries@5.2.0(postcss@8.5.3):
+  postcss-sort-media-queries@5.2.0(postcss@8.5.6):
     dependencies:
-      postcss: 8.5.3
+      postcss: 8.5.6
       sort-css-media-queries: 2.2.0
 
   postcss-svgo@6.0.3(postcss@8.5.3):
@@ -15190,16 +14974,27 @@ snapshots:
       postcss-value-parser: 4.2.0
       svgo: 3.3.2
 
+  postcss-svgo@6.0.3(postcss@8.5.6):
+    dependencies:
+      postcss: 8.5.6
+      postcss-value-parser: 4.2.0
+      svgo: 3.3.2
+
   postcss-unique-selectors@6.0.4(postcss@8.5.3):
     dependencies:
       postcss: 8.5.3
       postcss-selector-parser: 6.1.2
 
+  postcss-unique-selectors@6.0.4(postcss@8.5.6):
+    dependencies:
+      postcss: 8.5.6
+      postcss-selector-parser: 6.1.2
+
   postcss-value-parser@4.2.0: {}
 
-  postcss-zindex@6.0.2(postcss@8.5.3):
+  postcss-zindex@6.0.2(postcss@8.5.6):
     dependencies:
-      postcss: 8.5.3
+      postcss: 8.5.6
 
   postcss@8.5.3:
     dependencies:
@@ -15270,11 +15065,11 @@ snapshots:
 
   pure-rand@6.1.0: {}
 
-  qs@6.13.0:
+  qs@6.14.0:
     dependencies:
       side-channel: 1.1.0
 
-  qs@6.14.0:
+  qs@6.14.1:
     dependencies:
       side-channel: 1.1.0
 
@@ -15332,12 +15127,12 @@ snapshots:
       - react-router
       - react-router-dom
 
-  ra-ui-materialui@5.7.3(c3825bfcf53a37cf7fbad8ca26e2d2ec):
+  ra-ui-materialui@5.7.3(38c3b623149e891a41719a06c154e667):
     dependencies:
-      '@mui/icons-material': 6.4.11(@mui/material@6.4.11(@emotion/react@11.14.0(@types/react@19.1.0)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.0)(react@19.1.0))(@types/react@19.1.0)(react@19.1.0))(@types/react@19.1.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(@types/react@19.1.0)(react@19.1.0)
-      '@mui/material': 6.4.11(@emotion/react@11.14.0(@types/react@19.1.0)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.0)(react@19.1.0))(@types/react@19.1.0)(react@19.1.0))(@types/react@19.1.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@mui/system': 6.4.11(@emotion/react@11.14.0(@types/react@19.1.0)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.0)(react@19.1.0))(@types/react@19.1.0)(react@19.1.0))(@types/react@19.1.0)(react@19.1.0)
-      '@mui/utils': 6.4.9(@types/react@19.1.0)(react@19.1.0)
+      '@mui/icons-material': 6.4.11(@mui/material@6.4.11(@emotion/react@11.14.0(@types/react@19.2.9)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.2.9)(react@19.1.0))(@types/react@19.2.9)(react@19.1.0))(@types/react@19.2.9)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(@types/react@19.2.9)(react@19.1.0)
+      '@mui/material': 6.4.11(@emotion/react@11.14.0(@types/react@19.2.9)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.2.9)(react@19.1.0))(@types/react@19.2.9)(react@19.1.0))(@types/react@19.2.9)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@mui/system': 6.4.11(@emotion/react@11.14.0(@types/react@19.2.9)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.2.9)(react@19.1.0))(@types/react@19.2.9)(react@19.1.0))(@types/react@19.2.9)(react@19.1.0)
+      '@mui/utils': 6.4.9(@types/react@19.2.9)(react@19.1.0)
       '@tanstack/react-query': 5.74.4(react@19.1.0)
       autosuggest-highlight: 3.3.4
       clsx: 2.1.1
@@ -15366,18 +15161,18 @@ snapshots:
 
   range-parser@1.2.1: {}
 
-  raw-body@2.5.2:
+  raw-body@2.5.3:
     dependencies:
       bytes: 3.1.2
-      http-errors: 2.0.0
+      http-errors: 2.0.1
       iconv-lite: 0.4.24
       unpipe: 1.0.0
 
-  raw-body@3.0.0:
+  raw-body@3.0.2:
     dependencies:
       bytes: 3.1.2
-      http-errors: 2.0.0
-      iconv-lite: 0.6.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
       unpipe: 1.0.0
 
   rc@1.2.8:
@@ -15387,16 +15182,16 @@ snapshots:
       minimist: 1.2.8
       strip-json-comments: 2.0.1
 
-  react-admin@5.7.3(@mui/system@6.4.11(@emotion/react@11.14.0(@types/react@19.1.0)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.0)(react@19.1.0))(@types/react@19.1.0)(react@19.1.0))(@types/react@19.1.0)(react@19.1.0))(@mui/utils@6.4.9(@types/react@19.1.0)(react@19.1.0))(@types/react@19.1.0)(react-dom@19.1.0(react@19.1.0))(react-is@19.1.0)(react@19.1.0):
+  react-admin@5.7.3(@mui/system@6.4.11(@emotion/react@11.14.0(@types/react@19.2.9)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.2.9)(react@19.1.0))(@types/react@19.2.9)(react@19.1.0))(@types/react@19.2.9)(react@19.1.0))(@mui/utils@6.4.9(@types/react@19.2.9)(react@19.1.0))(@types/react@19.2.9)(react-dom@19.1.0(react@19.1.0))(react-is@19.1.0)(react@19.1.0):
     dependencies:
-      '@emotion/react': 11.14.0(@types/react@19.1.0)(react@19.1.0)
-      '@emotion/styled': 11.14.0(@emotion/react@11.14.0(@types/react@19.1.0)(react@19.1.0))(@types/react@19.1.0)(react@19.1.0)
-      '@mui/icons-material': 6.4.11(@mui/material@6.4.11(@emotion/react@11.14.0(@types/react@19.1.0)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.0)(react@19.1.0))(@types/react@19.1.0)(react@19.1.0))(@types/react@19.1.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(@types/react@19.1.0)(react@19.1.0)
-      '@mui/material': 6.4.11(@emotion/react@11.14.0(@types/react@19.1.0)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.0)(react@19.1.0))(@types/react@19.1.0)(react@19.1.0))(@types/react@19.1.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.9)(react@19.1.0)
+      '@emotion/styled': 11.14.0(@emotion/react@11.14.0(@types/react@19.2.9)(react@19.1.0))(@types/react@19.2.9)(react@19.1.0)
+      '@mui/icons-material': 6.4.11(@mui/material@6.4.11(@emotion/react@11.14.0(@types/react@19.2.9)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.2.9)(react@19.1.0))(@types/react@19.2.9)(react@19.1.0))(@types/react@19.2.9)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(@types/react@19.2.9)(react@19.1.0)
+      '@mui/material': 6.4.11(@emotion/react@11.14.0(@types/react@19.2.9)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.2.9)(react@19.1.0))(@types/react@19.2.9)(react@19.1.0))(@types/react@19.2.9)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       ra-core: 5.7.3(react-dom@19.1.0(react@19.1.0))(react-hook-form@7.55.0(react@19.1.0))(react-router-dom@7.5.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-router@7.5.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)
       ra-i18n-polyglot: 5.7.3(react-dom@19.1.0(react@19.1.0))(react-hook-form@7.55.0(react@19.1.0))(react-router-dom@7.5.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-router@7.5.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)
       ra-language-english: 5.7.3(react-dom@19.1.0(react@19.1.0))(react-hook-form@7.55.0(react@19.1.0))(react-router-dom@7.5.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-router@7.5.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)
-      ra-ui-materialui: 5.7.3(c3825bfcf53a37cf7fbad8ca26e2d2ec)
+      ra-ui-materialui: 5.7.3(38c3b623149e891a41719a06c154e667)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
       react-hook-form: 7.55.0(react@19.1.0)
@@ -15464,7 +15259,7 @@ snapshots:
 
   react-error-boundary@4.1.2(react@19.1.0):
     dependencies:
-      '@babel/runtime': 7.27.0
+      '@babel/runtime': 7.28.6
       react: 19.1.0
 
   react-error-overlay@6.1.0: {}
@@ -15539,7 +15334,7 @@ snapshots:
 
   react-transition-group@4.4.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
-      '@babel/runtime': 7.27.0
+      '@babel/runtime': 7.28.6
       dom-helpers: 5.2.1
       loose-envify: 1.4.0
       prop-types: 15.8.1
@@ -15604,7 +15399,7 @@ snapshots:
 
   recma-parse@1.0.0:
     dependencies:
-      '@types/estree': 1.0.7
+      '@types/estree': 1.0.8
       esast-util-from-js: 2.0.1
       unified: 11.0.5
       vfile: 6.0.3
@@ -15641,7 +15436,7 @@ snapshots:
 
   regenerator-transform@0.15.2:
     dependencies:
-      '@babel/runtime': 7.27.0
+      '@babel/runtime': 7.28.6
 
   regexp.prototype.flags@1.5.4:
     dependencies:
@@ -15812,32 +15607,6 @@ snapshots:
     dependencies:
       glob: 7.2.3
 
-  rollup@4.37.0:
-    dependencies:
-      '@types/estree': 1.0.6
-    optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.37.0
-      '@rollup/rollup-android-arm64': 4.37.0
-      '@rollup/rollup-darwin-arm64': 4.37.0
-      '@rollup/rollup-darwin-x64': 4.37.0
-      '@rollup/rollup-freebsd-arm64': 4.37.0
-      '@rollup/rollup-freebsd-x64': 4.37.0
-      '@rollup/rollup-linux-arm-gnueabihf': 4.37.0
-      '@rollup/rollup-linux-arm-musleabihf': 4.37.0
-      '@rollup/rollup-linux-arm64-gnu': 4.37.0
-      '@rollup/rollup-linux-arm64-musl': 4.37.0
-      '@rollup/rollup-linux-loongarch64-gnu': 4.37.0
-      '@rollup/rollup-linux-powerpc64le-gnu': 4.37.0
-      '@rollup/rollup-linux-riscv64-gnu': 4.37.0
-      '@rollup/rollup-linux-riscv64-musl': 4.37.0
-      '@rollup/rollup-linux-s390x-gnu': 4.37.0
-      '@rollup/rollup-linux-x64-gnu': 4.37.0
-      '@rollup/rollup-linux-x64-musl': 4.37.0
-      '@rollup/rollup-win32-arm64-msvc': 4.37.0
-      '@rollup/rollup-win32-ia32-msvc': 4.37.0
-      '@rollup/rollup-win32-x64-msvc': 4.37.0
-      fsevents: 2.3.3
-
   rollup@4.56.0:
     dependencies:
       '@types/estree': 1.0.8
@@ -15885,7 +15654,7 @@ snapshots:
     dependencies:
       escalade: 3.2.0
       picocolors: 1.1.1
-      postcss: 8.5.3
+      postcss: 8.5.6
       strip-json-comments: 3.1.1
 
   run-parallel@1.2.0:
@@ -16181,7 +15950,7 @@ snapshots:
 
   spdy-transport@3.0.0:
     dependencies:
-      debug: 4.4.0
+      debug: 4.4.3
       detect-node: 2.1.0
       hpack.js: 2.1.6
       obuf: 1.1.2
@@ -16192,7 +15961,7 @@ snapshots:
 
   spdy@4.0.2:
     dependencies:
-      debug: 4.4.0
+      debug: 4.4.3
       handle-thing: 2.0.1
       http-deceiver: 1.2.7
       select-hose: 2.0.0
@@ -16215,6 +15984,8 @@ snapshots:
   statuses@1.5.0: {}
 
   statuses@2.0.1: {}
+
+  statuses@2.0.2: {}
 
   std-env@3.10.0: {}
 
@@ -16325,6 +16096,12 @@ snapshots:
     dependencies:
       browserslist: 4.24.4
       postcss: 8.5.3
+      postcss-selector-parser: 6.1.2
+
+  stylehacks@6.1.1(postcss@8.5.6):
+    dependencies:
+      browserslist: 4.24.4
+      postcss: 8.5.6
       postcss-selector-parser: 6.1.2
 
   stylis@4.2.0: {}
@@ -16536,6 +16313,8 @@ snapshots:
 
   undici-types@6.21.0: {}
 
+  undici-types@7.16.0: {}
+
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 
   unicode-emoji-modifier-base@1.0.0: {}
@@ -16687,20 +16466,6 @@ snapshots:
   vite@6.3.2(@types/node@22.14.1)(jiti@2.4.2)(terser@5.39.0):
     dependencies:
       esbuild: 0.25.1
-      fdir: 6.4.3(picomatch@4.0.2)
-      picomatch: 4.0.2
-      postcss: 8.5.3
-      rollup: 4.37.0
-      tinyglobby: 0.2.12
-    optionalDependencies:
-      '@types/node': 22.14.1
-      fsevents: 2.3.3
-      jiti: 2.4.2
-      terser: 5.39.0
-
-  vite@7.3.1(@types/node@22.14.1)(jiti@2.4.2)(terser@5.39.0):
-    dependencies:
-      esbuild: 0.27.2
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
       postcss: 8.5.6
@@ -16712,16 +16477,30 @@ snapshots:
       jiti: 2.4.2
       terser: 5.39.0
 
-  vitest-mock-extended@3.1.0(typescript@5.8.3)(vitest@4.0.18(@types/node@22.14.1)(jiti@2.4.2)(jsdom@26.1.0)(terser@5.39.0)):
+  vite@6.3.2(@types/node@25.0.9)(jiti@2.4.2)(terser@5.39.0):
+    dependencies:
+      esbuild: 0.25.1
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.56.0
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 25.0.9
+      fsevents: 2.3.3
+      jiti: 2.4.2
+      terser: 5.39.0
+
+  vitest-mock-extended@3.1.0(typescript@5.8.3)(vitest@4.0.18(@types/node@25.0.9)(jiti@2.4.2)(jsdom@26.1.0)(terser@5.39.0)):
     dependencies:
       ts-essentials: 10.0.4(typescript@5.8.3)
       typescript: 5.8.3
-      vitest: 4.0.18(@types/node@22.14.1)(jiti@2.4.2)(jsdom@26.1.0)(terser@5.39.0)
+      vitest: 4.0.18(@types/node@25.0.9)(jiti@2.4.2)(jsdom@26.1.0)(terser@5.39.0)
 
   vitest@4.0.18(@types/node@22.14.1)(jiti@2.4.2)(jsdom@26.1.0)(terser@5.39.0):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@22.14.1)(jiti@2.4.2)(terser@5.39.0))
+      '@vitest/mocker': 4.0.18(vite@6.3.2(@types/node@22.14.1)(jiti@2.4.2)(terser@5.39.0))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18
@@ -16738,10 +16517,48 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.3.1(@types/node@22.14.1)(jiti@2.4.2)(terser@5.39.0)
+      vite: 6.3.2(@types/node@22.14.1)(jiti@2.4.2)(terser@5.39.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.14.1
+      jsdom: 26.1.0
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
+
+  vitest@4.0.18(@types/node@25.0.9)(jiti@2.4.2)(jsdom@26.1.0)(terser@5.39.0):
+    dependencies:
+      '@vitest/expect': 4.0.18
+      '@vitest/mocker': 4.0.18(vite@6.3.2(@types/node@25.0.9)(jiti@2.4.2)(terser@5.39.0))
+      '@vitest/pretty-format': 4.0.18
+      '@vitest/runner': 4.0.18
+      '@vitest/snapshot': 4.0.18
+      '@vitest/spy': 4.0.18
+      '@vitest/utils': 4.0.18
+      es-module-lexer: 1.7.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.0.3
+      vite: 6.3.2(@types/node@25.0.9)(jiti@2.4.2)(terser@5.39.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.0.9
       jsdom: 26.1.0
     transitivePeerDependencies:
       - jiti
@@ -16810,9 +16627,9 @@ snapshots:
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
-      '@types/express': 4.17.21
+      '@types/express': 4.17.25
       '@types/serve-index': 1.9.4
-      '@types/serve-static': 1.15.7
+      '@types/serve-static': 1.15.10
       '@types/sockjs': 0.3.36
       '@types/ws': 8.18.1
       ansi-html-community: 0.0.8
@@ -16822,10 +16639,10 @@ snapshots:
       compression: 1.8.0
       connect-history-api-fallback: 2.0.0
       default-gateway: 6.0.3
-      express: 4.21.2
+      express: 4.22.1
       graceful-fs: 4.2.11
       html-entities: 2.6.0
-      http-proxy-middleware: 2.0.9(@types/express@4.17.21)
+      http-proxy-middleware: 2.0.9(@types/express@4.17.25)
       ipaddr.js: 2.2.0
       launch-editor: 2.10.0
       open: 8.4.2


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core typing + Express response handling, including new runtime streaming behavior (`stream.pipe(res)` and default headers), which could affect existing endpoint integrations if misdetected or if headers/conflicting response paths occur.
> 
> **Overview**
> Adds first-class **streaming endpoint** support across `@ts-endpoint`.
> 
> Core introduces `StreamOutput()`/`StreamOutputCodec` to mark streaming outputs, updates `Endpoint`/`EndpointOutputType` and the http client to type such endpoints as `NodeJS.ReadableStream`, and updates the Express subscriber to accept `HTTPStreamResponse` and pipe streams with default SSE-style headers. The React/Express example is extended with a `streamUsers` endpoint plus a client UI demo to start/stop and display streamed chunks, and TanStack Query typings are adjusted to better accept serialized list query params.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 722fdfc6a88dadf8d9745ffcb1b87d61b020286e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->